### PR TITLE
Initialize SpvReflectShaderModule to zero at creation time. Fixes #21

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1807,6 +1807,9 @@ SpvReflectResult spvReflectGetShaderModule(
   SpvReflectShaderModule*  p_module
 )
 {
+  // Initialize all module fields to zero
+  memset(p_module, 0, sizeof(*p_module));
+
   // Allocate module internals
 #ifdef __cplusplus
   p_module->_internal = (SpvReflectShaderModule::Internal*)calloc(1, sizeof(*(p_module->_internal)));


### PR DESCRIPTION
I believe a simple memset is sufficient, even when compiling in C++. SpvReflectShaderModule is a C struct, which will never have virtual methods, and will thus never have a vtable.
Fight me.