### PR TITLE
Fix VS2015 build warning:

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2342,7 +2342,7 @@ static SpvReflectResult ParseFormat(
 )
 {
   SpvReflectResult result = SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR;
-  bool signedness = p_type->traits.numeric.scalar.signedness;
+  bool signedness = (p_type->traits.numeric.scalar.signedness != 0);
   if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_VECTOR) {
     uint32_t component_count = p_type->traits.numeric.vector.component_count;
     if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_FLOAT) {


### PR DESCRIPTION
spirv_reflect.c(2345): error C2220: warning treated as error - no 'object' file generated
spirv_reflect.c(2345): warning C4800: 'const uint32_t': forcing value to bool 'true' or 'false' (performance warning)