### PR TITLE
Add missing break statements.

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2528,6 +2528,8 @@ static SpvReflectResult ParseFormat(
             case 4: *p_format = SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT; break;
           }
         }
+        break;
+        
         case 64: {
           switch (component_count) {
             case 2: *p_format = SPV_REFLECT_FORMAT_R64G64_SFLOAT; break;
@@ -2547,6 +2549,8 @@ static SpvReflectResult ParseFormat(
             case 4: *p_format = signedness ? SPV_REFLECT_FORMAT_R32G32B32A32_SINT : SPV_REFLECT_FORMAT_R32G32B32A32_UINT; break;
           }
         }
+        break;
+        
         case 64: {
           switch (component_count) {
             case 2: *p_format = signedness ? SPV_REFLECT_FORMAT_R64G64_SINT : SPV_REFLECT_FORMAT_R64G64_UINT; break;


### PR DESCRIPTION
It seems like ParseFormat wrongly identifies 32-bit values as 64-bit values due to two break statements missing in commit https://github.com/KhronosGroup/SPIRV-Reflect/commit/00c4eb534cc5a23b6b941ee8875fda58c34fea3b. This PR should fix the problem.