### PR TITLE
Ensuring embedded source is freed before assignment; e.g. to handle #…

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -670,6 +670,7 @@ static SpvReflectResult ParseNodes(Parser* p_parser)
           strcpy(p_source_temp, p_source);
       #endif
 
+          SafeFree(p_parser->source_embedded);
           p_parser->source_embedded = p_source_temp;
         }
       }


### PR DESCRIPTION
When using an #include extension with glslc, two sources are provided with op = `SpvOpSource` (rather than as `SpvOpSourceContinued`).
Since there is currently only one slot, this new source replaces the existing source_embedded without freeing it.
There might be a better way to handle this (especially for debugging purposes), but at the very least this PR prevents the previous `source_embedded` from leaking.