### PR TITLE
Add accessed pointers through OpImageTexelPointer to entrypoint

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1034,6 +1034,7 @@ static SpvReflectResult ParseFunction(
       case SpvOpGenericPtrMemSemantics:
       case SpvOpInBoundsPtrAccessChain:
       case SpvOpStore:
+      case SpvOpImageTexelPointer:
       {
         ++(p_func->accessed_ptr_count);
       }
@@ -1085,6 +1086,7 @@ static SpvReflectResult ParseFunction(
       case SpvOpArrayLength:
       case SpvOpGenericPtrMemSemantics:
       case SpvOpInBoundsPtrAccessChain:
+      case SpvOpImageTexelPointer:
       {
         CHECKED_READU32(p_parser, p_node->word_offset + 3,
                         p_func->accessed_ptrs[p_func->accessed_ptr_count]);


### PR DESCRIPTION
Without this spvReflectEnumerateEntryPointDescriptorBindings omits all descriptor bindings from a function that are only accessed through `SpvOpImageTexelPointer`.
