### PR TITLE
Removed null test in SafeFree Macro

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -235,12 +235,10 @@ static uint32_t RoundUp(
 #define IsNotNull(ptr) \
   (ptr != NULL)
 
-#define SafeFree(ptr)    \
-  {                      \
-     if (ptr != NULL) {  \
-       free((void*)ptr); \
-       ptr = NULL;       \
-     }                   \
+#define SafeFree(ptr)  \
+  {                    \
+     free((void*)ptr); \
+     ptr = NULL;       \
   }
 
 static int SortCompareUint32(


### PR DESCRIPTION
Freeing a null pointer does nothing therefore it is redundant to check null before free.