### PR TITLE
Avoid undefined behavior in IntersectSortedUint32

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -303,7 +303,12 @@ static SpvReflectResult IntersectSortedUint32(
   size_t*         res_size
 )
 {
+  *pp_res = NULL;
   *res_size = 0;
+  if (IsNull(p_arr0) || IsNull(p_arr1)) {
+    return SPV_REFLECT_RESULT_SUCCESS;
+  }
+
   const uint32_t* arr0_end = p_arr0 + arr0_size;
   const uint32_t* arr1_end = p_arr1 + arr1_size;
 
@@ -321,7 +326,6 @@ static SpvReflectResult IntersectSortedUint32(
     }
   }
 
-  *pp_res = NULL;
   if (*res_size > 0) {
     *pp_res = (uint32_t*)calloc(*res_size, sizeof(**pp_res));
     if (IsNull(*pp_res)) {


### PR DESCRIPTION
Change `IntersectSortedUint32` to early exit out when one of its input arrays (`p_arr0` and `p_arr1`) is `NULL`. This way, the following arithmetic operations are not performed on **null pointers**:
https://github.com/KhronosGroup/SPIRV-Reflect/blob/5f6e13e06b8bd5a1eca190377b603bfd2aaa45ea/spirv_reflect.c#L307-L308

The result of `IntersectSortedUint32` in this case is a 0-sized output array (i.e. there is **no** intersection when one of the inputs is `NULL`). Hence, `*pp_res = NULL;` is moved to the top of the function to happen together with `*res_size = 0;`, correctly setting the output variables when returning successfully from the function.