### PR TITLE
Fix spurious alloc error when there are no execution modes

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -3339,11 +3339,13 @@ static SpvReflectResult ParseExecutionModes(
     }
     for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
       SpvReflectEntryPoint* p_entry_point = &p_module->entry_points[entry_point_idx];
-      p_entry_point->execution_modes =
-          (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
-      if (IsNull(p_entry_point->execution_modes)) {
-        SafeFree(indices);
-        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+      if (p_entry_point->execution_mode_count > 0) {
+        p_entry_point->execution_modes =
+            (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
+        if (IsNull(p_entry_point->execution_modes)) {
+          SafeFree(indices);
+          return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
       }
     }
 


### PR DESCRIPTION
`calloc()` returns `NULL` in some implementations when given a size of zero. This PR adds a guard for a case where that can happen in a valid shader to avoid a falsey `SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED` result.