### PR TITLE
Use same .clang-format as SPIRV-Tools

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+DerivePointerAlignment: false
+SortIncludes: true
+...

--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -8,35 +8,35 @@
 #include <vector>
 
 enum TextLineType {
-  TEXT_LINE_TYPE_BLOCK_BEGIN   = 0x01,
-  TEXT_LINE_TYPE_BLOCK_END     = 0x02,
-  TEXT_LINE_TYPE_STRUCT_BEGIN  = 0x04,
-  TEXT_LINE_TYPE_STRUCT_END    = 0x08,
-  TEXT_LINE_TYPE_LINES         = 0x10,
+  TEXT_LINE_TYPE_BLOCK_BEGIN = 0x01,
+  TEXT_LINE_TYPE_BLOCK_END = 0x02,
+  TEXT_LINE_TYPE_STRUCT_BEGIN = 0x04,
+  TEXT_LINE_TYPE_STRUCT_END = 0x08,
+  TEXT_LINE_TYPE_LINES = 0x10,
 };
 
 struct TextLine {
-  std::string           indent;
-  std::string           modifier;
-  std::string           type_name;
-  std::string           name;
-  uint32_t              absolute_offset;
-  uint32_t              relative_offset;
-  uint32_t              size;
-  uint32_t              padded_size;
-  uint32_t              array_stride;
-  uint32_t              block_variable_flags;
+  std::string indent;
+  std::string modifier;
+  std::string type_name;
+  std::string name;
+  uint32_t absolute_offset;
+  uint32_t relative_offset;
+  uint32_t size;
+  uint32_t padded_size;
+  uint32_t array_stride;
+  uint32_t block_variable_flags;
   std::vector<uint32_t> array_dims;
   // Text Data
-  uint32_t              text_line_flags;
+  uint32_t text_line_flags;
   std::vector<TextLine> lines;
-  std::string           formatted_line;
-  std::string           formatted_absolute_offset;
-  std::string           formatted_relative_offset;
-  std::string           formatted_size;
-  std::string           formatted_padded_size;
-  std::string           formatted_array_stride;
-  std::string           formatted_block_variable_flags;
+  std::string formatted_line;
+  std::string formatted_absolute_offset;
+  std::string formatted_relative_offset;
+  std::string formatted_size;
+  std::string formatted_padded_size;
+  std::string formatted_array_stride;
+  std::string formatted_block_variable_flags;
 };
 
 static std::string AsHexString(uint32_t n) {
@@ -48,34 +48,61 @@ static std::string AsHexString(uint32_t n) {
   return std::string(out_word);
 }
 
-std::string ToStringGenerator(SpvReflectGenerator generator)
-{
+std::string ToStringGenerator(SpvReflectGenerator generator) {
   switch (generator) {
-    case SPV_REFLECT_GENERATOR_KHRONOS_LLVM_SPIRV_TRANSLATOR         : return "Khronos LLVM/SPIR-V Translator"; break;
-    case SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_ASSEMBLER         : return "Khronos SPIR-V Tools Assembler"; break;
-    case SPV_REFLECT_GENERATOR_KHRONOS_GLSLANG_REFERENCE_FRONT_END   : return "Khronos Glslang Reference Front End"; break;
-    case SPV_REFLECT_GENERATOR_GOOGLE_SHADERC_OVER_GLSLANG           : return "Google Shaderc over Glslang"; break;
-    case SPV_REFLECT_GENERATOR_GOOGLE_SPIREGG                        : return "Google spiregg"; break;
-    case SPV_REFLECT_GENERATOR_GOOGLE_RSPIRV                         : return "Google rspirv"; break;
-    case SPV_REFLECT_GENERATOR_X_LEGEND_MESA_MESAIR_SPIRV_TRANSLATOR : return "X-LEGEND Mesa-IR/SPIR-V Translator"; break;
-    case SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_LINKER            : return "Khronos SPIR-V Tools Linker"; break;
-    case SPV_REFLECT_GENERATOR_WINE_VKD3D_SHADER_COMPILER            : return "Wine VKD3D Shader Compiler"; break;
-    case SPV_REFLECT_GENERATOR_CLAY_CLAY_SHADER_COMPILER             : return "Clay Clay Shader Compiler"; break;
+    case SPV_REFLECT_GENERATOR_KHRONOS_LLVM_SPIRV_TRANSLATOR:
+      return "Khronos LLVM/SPIR-V Translator";
+      break;
+    case SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_ASSEMBLER:
+      return "Khronos SPIR-V Tools Assembler";
+      break;
+    case SPV_REFLECT_GENERATOR_KHRONOS_GLSLANG_REFERENCE_FRONT_END:
+      return "Khronos Glslang Reference Front End";
+      break;
+    case SPV_REFLECT_GENERATOR_GOOGLE_SHADERC_OVER_GLSLANG:
+      return "Google Shaderc over Glslang";
+      break;
+    case SPV_REFLECT_GENERATOR_GOOGLE_SPIREGG:
+      return "Google spiregg";
+      break;
+    case SPV_REFLECT_GENERATOR_GOOGLE_RSPIRV:
+      return "Google rspirv";
+      break;
+    case SPV_REFLECT_GENERATOR_X_LEGEND_MESA_MESAIR_SPIRV_TRANSLATOR:
+      return "X-LEGEND Mesa-IR/SPIR-V Translator";
+      break;
+    case SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_LINKER:
+      return "Khronos SPIR-V Tools Linker";
+      break;
+    case SPV_REFLECT_GENERATOR_WINE_VKD3D_SHADER_COMPILER:
+      return "Wine VKD3D Shader Compiler";
+      break;
+    case SPV_REFLECT_GENERATOR_CLAY_CLAY_SHADER_COMPILER:
+      return "Clay Clay Shader Compiler";
+      break;
   }
   // unhandled SpvReflectGenerator enum value
   return "???";
 }
 
 std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang) {
-  switch(lang) {
-    case SpvSourceLanguageUnknown        : return "Unknown";
-    case SpvSourceLanguageESSL           : return "ESSL";
-    case SpvSourceLanguageGLSL           : return "GLSL";
-    case SpvSourceLanguageOpenCL_C       : return "OpenCL_C";
-    case SpvSourceLanguageOpenCL_CPP     : return "OpenCL_CPP";
-    case SpvSourceLanguageHLSL           : return "HLSL";
-    case SpvSourceLanguageCPP_for_OpenCL : return "CPP_for_OpenCL";
-    case SpvSourceLanguageSYCL           : return "SYCL";
+  switch (lang) {
+    case SpvSourceLanguageUnknown:
+      return "Unknown";
+    case SpvSourceLanguageESSL:
+      return "ESSL";
+    case SpvSourceLanguageGLSL:
+      return "GLSL";
+    case SpvSourceLanguageOpenCL_C:
+      return "OpenCL_C";
+    case SpvSourceLanguageOpenCL_CPP:
+      return "OpenCL_CPP";
+    case SpvSourceLanguageHLSL:
+      return "HLSL";
+    case SpvSourceLanguageCPP_for_OpenCL:
+      return "CPP_for_OpenCL";
+    case SpvSourceLanguageSYCL:
+      return "SYCL";
 
     case SpvSourceLanguageMax:
       break;
@@ -85,22 +112,37 @@ std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang) {
 }
 
 std::string ToStringSpvExecutionModel(SpvExecutionModel model) {
-  switch(model) {
-    case SpvExecutionModelVertex                 : return "Vertex";
-    case SpvExecutionModelTessellationControl    : return "TessellationControl";
-    case SpvExecutionModelTessellationEvaluation : return "TessellationEvaluation";
-    case SpvExecutionModelGeometry               : return "Geometry";
-    case SpvExecutionModelFragment               : return "Fragment";
-    case SpvExecutionModelGLCompute              : return "GLCompute";
-    case SpvExecutionModelKernel                 : return "Kernel";
-    case SpvExecutionModelTaskNV                 : return "TaskNV";
-    case SpvExecutionModelMeshNV                 : return "MeshNV";
-    case SpvExecutionModelRayGenerationKHR       : return "RayGenerationKHR";
-    case SpvExecutionModelIntersectionKHR        : return "IntersectionKHR";
-    case SpvExecutionModelAnyHitKHR              : return "AnyHitKHR";
-    case SpvExecutionModelClosestHitKHR          : return "ClosestHitKHR";
-    case SpvExecutionModelMissKHR                : return "MissKHR";
-    case SpvExecutionModelCallableKHR            : return "CallableKHR";
+  switch (model) {
+    case SpvExecutionModelVertex:
+      return "Vertex";
+    case SpvExecutionModelTessellationControl:
+      return "TessellationControl";
+    case SpvExecutionModelTessellationEvaluation:
+      return "TessellationEvaluation";
+    case SpvExecutionModelGeometry:
+      return "Geometry";
+    case SpvExecutionModelFragment:
+      return "Fragment";
+    case SpvExecutionModelGLCompute:
+      return "GLCompute";
+    case SpvExecutionModelKernel:
+      return "Kernel";
+    case SpvExecutionModelTaskNV:
+      return "TaskNV";
+    case SpvExecutionModelMeshNV:
+      return "MeshNV";
+    case SpvExecutionModelRayGenerationKHR:
+      return "RayGenerationKHR";
+    case SpvExecutionModelIntersectionKHR:
+      return "IntersectionKHR";
+    case SpvExecutionModelAnyHitKHR:
+      return "AnyHitKHR";
+    case SpvExecutionModelClosestHitKHR:
+      return "ClosestHitKHR";
+    case SpvExecutionModelMissKHR:
+      return "MissKHR";
+    case SpvExecutionModelCallableKHR:
+      return "CallableKHR";
 
     case SpvExecutionModelMax:
       break;
@@ -113,26 +155,39 @@ std::string ToStringSpvExecutionModel(SpvExecutionModel model) {
   return "???";
 }
 
-
 std::string ToStringShaderStage(SpvReflectShaderStageFlagBits stage) {
   switch (stage) {
-    case SPV_REFLECT_SHADER_STAGE_VERTEX_BIT                  : return "VS";
-    case SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT    : return "HS";
-    case SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT : return "DS";
-    case SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT                : return "GS";
-    case SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT                : return "PS";
-    case SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT                 : return "CS";
-    case SPV_REFLECT_SHADER_STAGE_TASK_BIT_NV                 : return "TASK";
-    case SPV_REFLECT_SHADER_STAGE_MESH_BIT_NV                 : return "MESH";
-    case SPV_REFLECT_SHADER_STAGE_RAYGEN_BIT_KHR              : return "RAYGEN";
-    case SPV_REFLECT_SHADER_STAGE_ANY_HIT_BIT_KHR             : return "ANY_HIT";
-    case SPV_REFLECT_SHADER_STAGE_CLOSEST_HIT_BIT_KHR         : return "CLOSEST_HIT";
-    case SPV_REFLECT_SHADER_STAGE_MISS_BIT_KHR                : return "MISS";
-    case SPV_REFLECT_SHADER_STAGE_INTERSECTION_BIT_KHR        : return "INTERSECTION";
-    case SPV_REFLECT_SHADER_STAGE_CALLABLE_BIT_KHR            : return "CALLABLE";
+    case SPV_REFLECT_SHADER_STAGE_VERTEX_BIT:
+      return "VS";
+    case SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+      return "HS";
+    case SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+      return "DS";
+    case SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT:
+      return "GS";
+    case SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT:
+      return "PS";
+    case SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT:
+      return "CS";
+    case SPV_REFLECT_SHADER_STAGE_TASK_BIT_NV:
+      return "TASK";
+    case SPV_REFLECT_SHADER_STAGE_MESH_BIT_NV:
+      return "MESH";
+    case SPV_REFLECT_SHADER_STAGE_RAYGEN_BIT_KHR:
+      return "RAYGEN";
+    case SPV_REFLECT_SHADER_STAGE_ANY_HIT_BIT_KHR:
+      return "ANY_HIT";
+    case SPV_REFLECT_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+      return "CLOSEST_HIT";
+    case SPV_REFLECT_SHADER_STAGE_MISS_BIT_KHR:
+      return "MISS";
+    case SPV_REFLECT_SHADER_STAGE_INTERSECTION_BIT_KHR:
+      return "INTERSECTION";
+    case SPV_REFLECT_SHADER_STAGE_CALLABLE_BIT_KHR:
+      return "CALLABLE";
 
     default:
-        break;
+      break;
   }
 
   // Unhandled SpvReflectShaderStageFlagBits enum value
@@ -140,38 +195,62 @@ std::string ToStringShaderStage(SpvReflectShaderStageFlagBits stage) {
 }
 
 std::string ToStringSpvStorageClass(SpvStorageClass storage_class) {
-  switch(storage_class) {
-    case SpvStorageClassUniformConstant         : return "UniformConstant";
-    case SpvStorageClassInput                   : return "Input";
-    case SpvStorageClassUniform                 : return "Uniform";
-    case SpvStorageClassOutput                  : return "Output";
-    case SpvStorageClassWorkgroup               : return "Workgroup";
-    case SpvStorageClassCrossWorkgroup          : return "CrossWorkgroup";
-    case SpvStorageClassPrivate                 : return "Private";
-    case SpvStorageClassFunction                : return "Function";
-    case SpvStorageClassGeneric                 : return "Generic";
-    case SpvStorageClassPushConstant            : return "PushConstant";
-    case SpvStorageClassAtomicCounter           : return "AtomicCounter";
-    case SpvStorageClassImage                   : return "Image";
-    case SpvStorageClassStorageBuffer           : return "StorageBuffer";
-    case SpvStorageClassCallableDataKHR         : return "CallableDataKHR";
-    case SpvStorageClassIncomingCallableDataKHR : return "IncomingCallableDataKHR";
-    case SpvStorageClassRayPayloadKHR           : return "RayPayloadKHR";
-    case SpvStorageClassHitAttributeKHR         : return "HitAttributeKHR";
-    case SpvStorageClassIncomingRayPayloadKHR   : return "IncomingRayPayloadKHR";
-    case SpvStorageClassShaderRecordBufferKHR   : return "ShaderRecordBufferKHR";
-    case SpvStorageClassPhysicalStorageBuffer   : return "PhysicalStorageBuffer";
-    case SpvStorageClassCodeSectionINTEL        : return "CodeSectionINTEL";
-    case SpvStorageClassDeviceOnlyINTEL         : return "DeviceOnlyINTEL";
-    case SpvStorageClassHostOnlyINTEL           : return "HostOnlyINTEL";
+  switch (storage_class) {
+    case SpvStorageClassUniformConstant:
+      return "UniformConstant";
+    case SpvStorageClassInput:
+      return "Input";
+    case SpvStorageClassUniform:
+      return "Uniform";
+    case SpvStorageClassOutput:
+      return "Output";
+    case SpvStorageClassWorkgroup:
+      return "Workgroup";
+    case SpvStorageClassCrossWorkgroup:
+      return "CrossWorkgroup";
+    case SpvStorageClassPrivate:
+      return "Private";
+    case SpvStorageClassFunction:
+      return "Function";
+    case SpvStorageClassGeneric:
+      return "Generic";
+    case SpvStorageClassPushConstant:
+      return "PushConstant";
+    case SpvStorageClassAtomicCounter:
+      return "AtomicCounter";
+    case SpvStorageClassImage:
+      return "Image";
+    case SpvStorageClassStorageBuffer:
+      return "StorageBuffer";
+    case SpvStorageClassCallableDataKHR:
+      return "CallableDataKHR";
+    case SpvStorageClassIncomingCallableDataKHR:
+      return "IncomingCallableDataKHR";
+    case SpvStorageClassRayPayloadKHR:
+      return "RayPayloadKHR";
+    case SpvStorageClassHitAttributeKHR:
+      return "HitAttributeKHR";
+    case SpvStorageClassIncomingRayPayloadKHR:
+      return "IncomingRayPayloadKHR";
+    case SpvStorageClassShaderRecordBufferKHR:
+      return "ShaderRecordBufferKHR";
+    case SpvStorageClassPhysicalStorageBuffer:
+      return "PhysicalStorageBuffer";
+    case SpvStorageClassCodeSectionINTEL:
+      return "CodeSectionINTEL";
+    case SpvStorageClassDeviceOnlyINTEL:
+      return "DeviceOnlyINTEL";
+    case SpvStorageClassHostOnlyINTEL:
+      return "HostOnlyINTEL";
     case SpvStorageClassMax:
       break;
-    
+
     default:
       break;
   }
 
-  // Special case: this specific "unhandled" value does actually seem to show up.
+  // Special case: this specific "unhandled" value does actually seem to show
+  // up.
   if (storage_class == (SpvStorageClass)-1) {
     return "NOT APPLICABLE";
   }
@@ -181,14 +260,21 @@ std::string ToStringSpvStorageClass(SpvStorageClass storage_class) {
 }
 
 std::string ToStringSpvDim(SpvDim dim) {
-  switch(dim) {
-    case SpvDim1D          : return "1D";
-    case SpvDim2D          : return "2D";
-    case SpvDim3D          : return "3D";
-    case SpvDimCube        : return "Cube";
-    case SpvDimRect        : return "Rect";
-    case SpvDimBuffer      : return "Buffer";
-    case SpvDimSubpassData : return "SubpassData";
+  switch (dim) {
+    case SpvDim1D:
+      return "1D";
+    case SpvDim2D:
+      return "2D";
+    case SpvDim3D:
+      return "3D";
+    case SpvDimCube:
+      return "Cube";
+    case SpvDimRect:
+      return "Rect";
+    case SpvDimBuffer:
+      return "Buffer";
+    case SpvDimSubpassData:
+      return "SubpassData";
 
     case SpvDimMax:
       break;
@@ -197,14 +283,18 @@ std::string ToStringSpvDim(SpvDim dim) {
   return "???";
 }
 
-
 std::string ToStringResourceType(SpvReflectResourceType res_type) {
-  switch(res_type) {
-    case SPV_REFLECT_RESOURCE_FLAG_UNDEFINED : return "UNDEFINED";
-    case SPV_REFLECT_RESOURCE_FLAG_SAMPLER   : return "SAMPLER";
-    case SPV_REFLECT_RESOURCE_FLAG_CBV       : return "CBV";
-    case SPV_REFLECT_RESOURCE_FLAG_SRV       : return "SRV";
-    case SPV_REFLECT_RESOURCE_FLAG_UAV       : return "UAV";
+  switch (res_type) {
+    case SPV_REFLECT_RESOURCE_FLAG_UNDEFINED:
+      return "UNDEFINED";
+    case SPV_REFLECT_RESOURCE_FLAG_SAMPLER:
+      return "SAMPLER";
+    case SPV_REFLECT_RESOURCE_FLAG_CBV:
+      return "CBV";
+    case SPV_REFLECT_RESOURCE_FLAG_SRV:
+      return "SRV";
+    case SPV_REFLECT_RESOURCE_FLAG_UAV:
+      return "UAV";
   }
   // unhandled SpvReflectResourceType enum value
   return "???";
@@ -212,18 +302,30 @@ std::string ToStringResourceType(SpvReflectResourceType res_type) {
 
 std::string ToStringDescriptorType(SpvReflectDescriptorType value) {
   switch (value) {
-    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER                    : return "VK_DESCRIPTOR_TYPE_SAMPLER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER     : return "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE              : return "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE              : return "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER       : return "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER       : return "VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER             : return "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER             : return "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC     : return "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC     : return "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT           : return "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT";
-    case SPV_REFLECT_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR : return "VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER:
+      return "VK_DESCRIPTOR_TYPE_SAMPLER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+      return "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+      return "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+      return "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+      return "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+      return "VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+      return "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+      return "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+      return "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+      return "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+      return "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT";
+    case SPV_REFLECT_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+      return "VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR";
   }
   // unhandled SpvReflectDescriptorType enum value
   return "VK_DESCRIPTOR_TYPE_???";
@@ -231,85 +333,164 @@ std::string ToStringDescriptorType(SpvReflectDescriptorType value) {
 
 std::string ToStringSpvBuiltIn(SpvBuiltIn built_in) {
   switch (built_in) {
-    case SpvBuiltInPosition                    : return "Position";
-    case SpvBuiltInPointSize                   : return "PointSize";
-    case SpvBuiltInClipDistance                : return "ClipDistance";
-    case SpvBuiltInCullDistance                : return "CullDistance";
-    case SpvBuiltInVertexId                    : return "VertexId";
-    case SpvBuiltInInstanceId                  : return "InstanceId";
-    case SpvBuiltInPrimitiveId                 : return "PrimitiveId";
-    case SpvBuiltInInvocationId                : return "InvocationId";
-    case SpvBuiltInLayer                       : return "Layer";
-    case SpvBuiltInViewportIndex               : return "ViewportIndex";
-    case SpvBuiltInTessLevelOuter              : return "TessLevelOuter";
-    case SpvBuiltInTessLevelInner              : return "TessLevelInner";
-    case SpvBuiltInTessCoord                   : return "TessCoord";
-    case SpvBuiltInPatchVertices               : return "PatchVertices";
-    case SpvBuiltInFragCoord                   : return "FragCoord";
-    case SpvBuiltInPointCoord                  : return "PointCoord";
-    case SpvBuiltInFrontFacing                 : return "FrontFacing";
-    case SpvBuiltInSampleId                    : return "SampleId";
-    case SpvBuiltInSamplePosition              : return "SamplePosition";
-    case SpvBuiltInSampleMask                  : return "SampleMask";
-    case SpvBuiltInFragDepth                   : return "FragDepth";
-    case SpvBuiltInHelperInvocation            : return "HelperInvocation";
-    case SpvBuiltInNumWorkgroups               : return "NumWorkgroups";
-    case SpvBuiltInWorkgroupSize               : return "WorkgroupSize";
-    case SpvBuiltInWorkgroupId                 : return "WorkgroupId";
-    case SpvBuiltInLocalInvocationId           : return "LocalInvocationId";
-    case SpvBuiltInGlobalInvocationId          : return "GlobalInvocationId";
-    case SpvBuiltInLocalInvocationIndex        : return "LocalInvocationIndex";
-    case SpvBuiltInWorkDim                     : return "WorkDim";
-    case SpvBuiltInGlobalSize                  : return "GlobalSize";
-    case SpvBuiltInEnqueuedWorkgroupSize       : return "EnqueuedWorkgroupSize";
-    case SpvBuiltInGlobalOffset                : return "GlobalOffset";
-    case SpvBuiltInGlobalLinearId              : return "GlobalLinearId";
-    case SpvBuiltInSubgroupSize                : return "SubgroupSize";
-    case SpvBuiltInSubgroupMaxSize             : return "SubgroupMaxSize";
-    case SpvBuiltInNumSubgroups                : return "NumSubgroups";
-    case SpvBuiltInNumEnqueuedSubgroups        : return "NumEnqueuedSubgroups";
-    case SpvBuiltInSubgroupId                  : return "SubgroupId";
-    case SpvBuiltInSubgroupLocalInvocationId   : return "SubgroupLocalInvocationId";
-    case SpvBuiltInVertexIndex                 : return "VertexIndex";
-    case SpvBuiltInInstanceIndex               : return "InstanceIndex";
-    case SpvBuiltInSubgroupEqMaskKHR           : return "SubgroupEqMaskKHR";
-    case SpvBuiltInSubgroupGeMaskKHR           : return "SubgroupGeMaskKHR";
-    case SpvBuiltInSubgroupGtMaskKHR           : return "SubgroupGtMaskKHR";
-    case SpvBuiltInSubgroupLeMaskKHR           : return "SubgroupLeMaskKHR";
-    case SpvBuiltInSubgroupLtMaskKHR           : return "SubgroupLtMaskKHR";
-    case SpvBuiltInBaseVertex                  : return "BaseVertex";
-    case SpvBuiltInBaseInstance                : return "BaseInstance";
-    case SpvBuiltInDrawIndex                   : return "DrawIndex";
-    case SpvBuiltInDeviceIndex                 : return "DeviceIndex";
-    case SpvBuiltInViewIndex                   : return "ViewIndex";
-    case SpvBuiltInBaryCoordNoPerspAMD         : return "BaryCoordNoPerspAMD";
-    case SpvBuiltInBaryCoordNoPerspCentroidAMD : return "BaryCoordNoPerspCentroidAMD";
-    case SpvBuiltInBaryCoordNoPerspSampleAMD   : return "BaryCoordNoPerspSampleAMD";
-    case SpvBuiltInBaryCoordSmoothAMD          : return "BaryCoordSmoothAMD";
-    case SpvBuiltInBaryCoordSmoothCentroidAMD  : return "BaryCoordSmoothCentroidAMD";
-    case SpvBuiltInBaryCoordSmoothSampleAMD    : return "BaryCoordSmoothSampleAMD";
-    case SpvBuiltInBaryCoordPullModelAMD       : return "BaryCoordPullModelAMD";
-    case SpvBuiltInFragStencilRefEXT           : return "FragStencilRefEXT";
-    case SpvBuiltInViewportMaskNV              : return "ViewportMaskNV";
-    case SpvBuiltInSecondaryPositionNV         : return "SecondaryPositionNV";
-    case SpvBuiltInSecondaryViewportMaskNV     : return "SecondaryViewportMaskNV";
-    case SpvBuiltInPositionPerViewNV           : return "PositionPerViewNV";
-    case SpvBuiltInViewportMaskPerViewNV       : return "ViewportMaskPerViewNV";
-    case SpvBuiltInLaunchIdKHR                 : return "InLaunchIdKHR";
-    case SpvBuiltInLaunchSizeKHR               : return "InLaunchSizeKHR";
-    case SpvBuiltInWorldRayOriginKHR           : return "InWorldRayOriginKHR";
-    case SpvBuiltInWorldRayDirectionKHR        : return "InWorldRayDirectionKHR";
-    case SpvBuiltInObjectRayOriginKHR          : return "InObjectRayOriginKHR";
-    case SpvBuiltInObjectRayDirectionKHR       : return "InObjectRayDirectionKHR";
-    case SpvBuiltInRayTminKHR                  : return "InRayTminKHR";
-    case SpvBuiltInRayTmaxKHR                  : return "InRayTmaxKHR";
-    case SpvBuiltInInstanceCustomIndexKHR      : return "InInstanceCustomIndexKHR";
-    case SpvBuiltInObjectToWorldKHR            : return "InObjectToWorldKHR";
-    case SpvBuiltInWorldToObjectKHR            : return "InWorldToObjectKHR";
-    case SpvBuiltInHitTNV                      : return "InHitTNV";
-    case SpvBuiltInHitKindKHR                  : return "InHitKindKHR";
-    case SpvBuiltInIncomingRayFlagsKHR         : return "InIncomingRayFlagsKHR";
-    case SpvBuiltInRayGeometryIndexKHR         : return "InRayGeometryIndexKHR";
+    case SpvBuiltInPosition:
+      return "Position";
+    case SpvBuiltInPointSize:
+      return "PointSize";
+    case SpvBuiltInClipDistance:
+      return "ClipDistance";
+    case SpvBuiltInCullDistance:
+      return "CullDistance";
+    case SpvBuiltInVertexId:
+      return "VertexId";
+    case SpvBuiltInInstanceId:
+      return "InstanceId";
+    case SpvBuiltInPrimitiveId:
+      return "PrimitiveId";
+    case SpvBuiltInInvocationId:
+      return "InvocationId";
+    case SpvBuiltInLayer:
+      return "Layer";
+    case SpvBuiltInViewportIndex:
+      return "ViewportIndex";
+    case SpvBuiltInTessLevelOuter:
+      return "TessLevelOuter";
+    case SpvBuiltInTessLevelInner:
+      return "TessLevelInner";
+    case SpvBuiltInTessCoord:
+      return "TessCoord";
+    case SpvBuiltInPatchVertices:
+      return "PatchVertices";
+    case SpvBuiltInFragCoord:
+      return "FragCoord";
+    case SpvBuiltInPointCoord:
+      return "PointCoord";
+    case SpvBuiltInFrontFacing:
+      return "FrontFacing";
+    case SpvBuiltInSampleId:
+      return "SampleId";
+    case SpvBuiltInSamplePosition:
+      return "SamplePosition";
+    case SpvBuiltInSampleMask:
+      return "SampleMask";
+    case SpvBuiltInFragDepth:
+      return "FragDepth";
+    case SpvBuiltInHelperInvocation:
+      return "HelperInvocation";
+    case SpvBuiltInNumWorkgroups:
+      return "NumWorkgroups";
+    case SpvBuiltInWorkgroupSize:
+      return "WorkgroupSize";
+    case SpvBuiltInWorkgroupId:
+      return "WorkgroupId";
+    case SpvBuiltInLocalInvocationId:
+      return "LocalInvocationId";
+    case SpvBuiltInGlobalInvocationId:
+      return "GlobalInvocationId";
+    case SpvBuiltInLocalInvocationIndex:
+      return "LocalInvocationIndex";
+    case SpvBuiltInWorkDim:
+      return "WorkDim";
+    case SpvBuiltInGlobalSize:
+      return "GlobalSize";
+    case SpvBuiltInEnqueuedWorkgroupSize:
+      return "EnqueuedWorkgroupSize";
+    case SpvBuiltInGlobalOffset:
+      return "GlobalOffset";
+    case SpvBuiltInGlobalLinearId:
+      return "GlobalLinearId";
+    case SpvBuiltInSubgroupSize:
+      return "SubgroupSize";
+    case SpvBuiltInSubgroupMaxSize:
+      return "SubgroupMaxSize";
+    case SpvBuiltInNumSubgroups:
+      return "NumSubgroups";
+    case SpvBuiltInNumEnqueuedSubgroups:
+      return "NumEnqueuedSubgroups";
+    case SpvBuiltInSubgroupId:
+      return "SubgroupId";
+    case SpvBuiltInSubgroupLocalInvocationId:
+      return "SubgroupLocalInvocationId";
+    case SpvBuiltInVertexIndex:
+      return "VertexIndex";
+    case SpvBuiltInInstanceIndex:
+      return "InstanceIndex";
+    case SpvBuiltInSubgroupEqMaskKHR:
+      return "SubgroupEqMaskKHR";
+    case SpvBuiltInSubgroupGeMaskKHR:
+      return "SubgroupGeMaskKHR";
+    case SpvBuiltInSubgroupGtMaskKHR:
+      return "SubgroupGtMaskKHR";
+    case SpvBuiltInSubgroupLeMaskKHR:
+      return "SubgroupLeMaskKHR";
+    case SpvBuiltInSubgroupLtMaskKHR:
+      return "SubgroupLtMaskKHR";
+    case SpvBuiltInBaseVertex:
+      return "BaseVertex";
+    case SpvBuiltInBaseInstance:
+      return "BaseInstance";
+    case SpvBuiltInDrawIndex:
+      return "DrawIndex";
+    case SpvBuiltInDeviceIndex:
+      return "DeviceIndex";
+    case SpvBuiltInViewIndex:
+      return "ViewIndex";
+    case SpvBuiltInBaryCoordNoPerspAMD:
+      return "BaryCoordNoPerspAMD";
+    case SpvBuiltInBaryCoordNoPerspCentroidAMD:
+      return "BaryCoordNoPerspCentroidAMD";
+    case SpvBuiltInBaryCoordNoPerspSampleAMD:
+      return "BaryCoordNoPerspSampleAMD";
+    case SpvBuiltInBaryCoordSmoothAMD:
+      return "BaryCoordSmoothAMD";
+    case SpvBuiltInBaryCoordSmoothCentroidAMD:
+      return "BaryCoordSmoothCentroidAMD";
+    case SpvBuiltInBaryCoordSmoothSampleAMD:
+      return "BaryCoordSmoothSampleAMD";
+    case SpvBuiltInBaryCoordPullModelAMD:
+      return "BaryCoordPullModelAMD";
+    case SpvBuiltInFragStencilRefEXT:
+      return "FragStencilRefEXT";
+    case SpvBuiltInViewportMaskNV:
+      return "ViewportMaskNV";
+    case SpvBuiltInSecondaryPositionNV:
+      return "SecondaryPositionNV";
+    case SpvBuiltInSecondaryViewportMaskNV:
+      return "SecondaryViewportMaskNV";
+    case SpvBuiltInPositionPerViewNV:
+      return "PositionPerViewNV";
+    case SpvBuiltInViewportMaskPerViewNV:
+      return "ViewportMaskPerViewNV";
+    case SpvBuiltInLaunchIdKHR:
+      return "InLaunchIdKHR";
+    case SpvBuiltInLaunchSizeKHR:
+      return "InLaunchSizeKHR";
+    case SpvBuiltInWorldRayOriginKHR:
+      return "InWorldRayOriginKHR";
+    case SpvBuiltInWorldRayDirectionKHR:
+      return "InWorldRayDirectionKHR";
+    case SpvBuiltInObjectRayOriginKHR:
+      return "InObjectRayOriginKHR";
+    case SpvBuiltInObjectRayDirectionKHR:
+      return "InObjectRayDirectionKHR";
+    case SpvBuiltInRayTminKHR:
+      return "InRayTminKHR";
+    case SpvBuiltInRayTmaxKHR:
+      return "InRayTmaxKHR";
+    case SpvBuiltInInstanceCustomIndexKHR:
+      return "InInstanceCustomIndexKHR";
+    case SpvBuiltInObjectToWorldKHR:
+      return "InObjectToWorldKHR";
+    case SpvBuiltInWorldToObjectKHR:
+      return "InWorldToObjectKHR";
+    case SpvBuiltInHitTNV:
+      return "InHitTNV";
+    case SpvBuiltInHitKindKHR:
+      return "InHitKindKHR";
+    case SpvBuiltInIncomingRayFlagsKHR:
+      return "InIncomingRayFlagsKHR";
+    case SpvBuiltInRayGeometryIndexKHR:
+      return "InRayGeometryIndexKHR";
 
     case SpvBuiltInMax:
     default:
@@ -322,49 +503,91 @@ std::string ToStringSpvBuiltIn(SpvBuiltIn built_in) {
 }
 
 std::string ToStringSpvImageFormat(SpvImageFormat fmt) {
-  switch(fmt) {
-    case SpvImageFormatUnknown      : return "Unknown";
-    case SpvImageFormatRgba32f      : return "Rgba32f";
-    case SpvImageFormatRgba16f      : return "Rgba16f";
-    case SpvImageFormatR32f         : return "R32f";
-    case SpvImageFormatRgba8        : return "Rgba8";
-    case SpvImageFormatRgba8Snorm   : return "Rgba8Snorm";
-    case SpvImageFormatRg32f        : return "Rg32f";
-    case SpvImageFormatRg16f        : return "Rg16f";
-    case SpvImageFormatR11fG11fB10f : return "R11fG11fB10f";
-    case SpvImageFormatR16f         : return "R16f";
-    case SpvImageFormatRgba16       : return "Rgba16";
-    case SpvImageFormatRgb10A2      : return "Rgb10A2";
-    case SpvImageFormatRg16         : return "Rg16";
-    case SpvImageFormatRg8          : return "Rg8";
-    case SpvImageFormatR16          : return "R16";
-    case SpvImageFormatR8           : return "R8";
-    case SpvImageFormatRgba16Snorm  : return "Rgba16Snorm";
-    case SpvImageFormatRg16Snorm    : return "Rg16Snorm";
-    case SpvImageFormatRg8Snorm     : return "Rg8Snorm";
-    case SpvImageFormatR16Snorm     : return "R16Snorm";
-    case SpvImageFormatR8Snorm      : return "R8Snorm";
-    case SpvImageFormatRgba32i      : return "Rgba32i";
-    case SpvImageFormatRgba16i      : return "Rgba16i";
-    case SpvImageFormatRgba8i       : return "Rgba8i";
-    case SpvImageFormatR32i         : return "R32i";
-    case SpvImageFormatRg32i        : return "Rg32i";
-    case SpvImageFormatRg16i        : return "Rg16i";
-    case SpvImageFormatRg8i         : return "Rg8i";
-    case SpvImageFormatR16i         : return "R16i";
-    case SpvImageFormatR8i          : return "R8i";
-    case SpvImageFormatRgba32ui     : return "Rgba32ui";
-    case SpvImageFormatRgba16ui     : return "Rgba16ui";
-    case SpvImageFormatRgba8ui      : return "Rgba8ui";
-    case SpvImageFormatR32ui        : return "R32ui";
-    case SpvImageFormatRgb10a2ui    : return "Rgb10a2ui";
-    case SpvImageFormatRg32ui       : return "Rg32ui";
-    case SpvImageFormatRg16ui       : return "Rg16ui";
-    case SpvImageFormatRg8ui        : return "Rg8ui";
-    case SpvImageFormatR16ui        : return "R16ui";
-    case SpvImageFormatR8ui         : return "R8ui";
-    case SpvImageFormatR64ui        : return "R64ui";
-    case SpvImageFormatR64i         : return "R64i";
+  switch (fmt) {
+    case SpvImageFormatUnknown:
+      return "Unknown";
+    case SpvImageFormatRgba32f:
+      return "Rgba32f";
+    case SpvImageFormatRgba16f:
+      return "Rgba16f";
+    case SpvImageFormatR32f:
+      return "R32f";
+    case SpvImageFormatRgba8:
+      return "Rgba8";
+    case SpvImageFormatRgba8Snorm:
+      return "Rgba8Snorm";
+    case SpvImageFormatRg32f:
+      return "Rg32f";
+    case SpvImageFormatRg16f:
+      return "Rg16f";
+    case SpvImageFormatR11fG11fB10f:
+      return "R11fG11fB10f";
+    case SpvImageFormatR16f:
+      return "R16f";
+    case SpvImageFormatRgba16:
+      return "Rgba16";
+    case SpvImageFormatRgb10A2:
+      return "Rgb10A2";
+    case SpvImageFormatRg16:
+      return "Rg16";
+    case SpvImageFormatRg8:
+      return "Rg8";
+    case SpvImageFormatR16:
+      return "R16";
+    case SpvImageFormatR8:
+      return "R8";
+    case SpvImageFormatRgba16Snorm:
+      return "Rgba16Snorm";
+    case SpvImageFormatRg16Snorm:
+      return "Rg16Snorm";
+    case SpvImageFormatRg8Snorm:
+      return "Rg8Snorm";
+    case SpvImageFormatR16Snorm:
+      return "R16Snorm";
+    case SpvImageFormatR8Snorm:
+      return "R8Snorm";
+    case SpvImageFormatRgba32i:
+      return "Rgba32i";
+    case SpvImageFormatRgba16i:
+      return "Rgba16i";
+    case SpvImageFormatRgba8i:
+      return "Rgba8i";
+    case SpvImageFormatR32i:
+      return "R32i";
+    case SpvImageFormatRg32i:
+      return "Rg32i";
+    case SpvImageFormatRg16i:
+      return "Rg16i";
+    case SpvImageFormatRg8i:
+      return "Rg8i";
+    case SpvImageFormatR16i:
+      return "R16i";
+    case SpvImageFormatR8i:
+      return "R8i";
+    case SpvImageFormatRgba32ui:
+      return "Rgba32ui";
+    case SpvImageFormatRgba16ui:
+      return "Rgba16ui";
+    case SpvImageFormatRgba8ui:
+      return "Rgba8ui";
+    case SpvImageFormatR32ui:
+      return "R32ui";
+    case SpvImageFormatRgb10a2ui:
+      return "Rgb10a2ui";
+    case SpvImageFormatRg32ui:
+      return "Rg32ui";
+    case SpvImageFormatRg16ui:
+      return "Rg16ui";
+    case SpvImageFormatRg8ui:
+      return "Rg8ui";
+    case SpvImageFormatR16ui:
+      return "R16ui";
+    case SpvImageFormatR8ui:
+      return "R8ui";
+    case SpvImageFormatR64ui:
+      return "R64ui";
+    case SpvImageFormatR64i:
+      return "R64i";
 
     case SpvImageFormatMax:
       break;
@@ -379,9 +602,10 @@ std::string ToStringTypeFlags(SpvReflectTypeFlags type_flags) {
   }
 
 #define PRINT_AND_CLEAR_TYPE_FLAG(stream, flags, bit) \
-  if (( (flags) & (SPV_REFLECT_TYPE_FLAG_##bit) ) == (SPV_REFLECT_TYPE_FLAG_##bit)) { \
-    stream << #bit << " "; \
-    flags ^= SPV_REFLECT_TYPE_FLAG_##bit; \
+  if (((flags) & (SPV_REFLECT_TYPE_FLAG_##bit)) ==    \
+      (SPV_REFLECT_TYPE_FLAG_##bit)) {                \
+    stream << #bit << " ";                            \
+    flags ^= SPV_REFLECT_TYPE_FLAG_##bit;             \
   }
   std::stringstream sstream;
   PRINT_AND_CLEAR_TYPE_FLAG(sstream, type_flags, ARRAY);
@@ -405,15 +629,17 @@ std::string ToStringTypeFlags(SpvReflectTypeFlags type_flags) {
   return sstream.str();
 }
 
-std::string ToStringDecorationFlags(SpvReflectDecorationFlags decoration_flags) {
+std::string ToStringDecorationFlags(
+    SpvReflectDecorationFlags decoration_flags) {
   if (decoration_flags == SPV_REFLECT_DECORATION_NONE) {
     return "NONE";
   }
 
 #define PRINT_AND_CLEAR_DECORATION_FLAG(stream, flags, bit) \
-  if (( (flags) & (SPV_REFLECT_DECORATION_##bit) ) == (SPV_REFLECT_DECORATION_##bit)) { \
-    stream << #bit << " "; \
-    flags ^= SPV_REFLECT_DECORATION_##bit; \
+  if (((flags) & (SPV_REFLECT_DECORATION_##bit)) ==         \
+      (SPV_REFLECT_DECORATION_##bit)) {                     \
+    stream << #bit << " ";                                  \
+    flags ^= SPV_REFLECT_DECORATION_##bit;                  \
   }
   std::stringstream sstream;
   PRINT_AND_CLEAR_DECORATION_FLAG(sstream, decoration_flags, NON_WRITABLE);
@@ -433,40 +659,64 @@ std::string ToStringDecorationFlags(SpvReflectDecorationFlags decoration_flags) 
 }
 
 std::string ToStringFormat(SpvReflectFormat fmt) {
-  switch(fmt) {
-    case SPV_REFLECT_FORMAT_UNDEFINED           : return "VK_FORMAT_UNDEFINED";
-    case SPV_REFLECT_FORMAT_R32_UINT            : return "VK_FORMAT_R32_UINT";
-    case SPV_REFLECT_FORMAT_R32_SINT            : return "VK_FORMAT_R32_SINT";
-    case SPV_REFLECT_FORMAT_R32_SFLOAT          : return "VK_FORMAT_R32_SFLOAT";
-    case SPV_REFLECT_FORMAT_R32G32_UINT         : return "VK_FORMAT_R32G32_UINT";
-    case SPV_REFLECT_FORMAT_R32G32_SINT         : return "VK_FORMAT_R32G32_SINT";
-    case SPV_REFLECT_FORMAT_R32G32_SFLOAT       : return "VK_FORMAT_R32G32_SFLOAT";
-    case SPV_REFLECT_FORMAT_R32G32B32_UINT      : return "VK_FORMAT_R32G32B32_UINT";
-    case SPV_REFLECT_FORMAT_R32G32B32_SINT      : return "VK_FORMAT_R32G32B32_SINT";
-    case SPV_REFLECT_FORMAT_R32G32B32_SFLOAT    : return "VK_FORMAT_R32G32B32_SFLOAT";
-    case SPV_REFLECT_FORMAT_R32G32B32A32_UINT   : return "VK_FORMAT_R32G32B32A32_UINT";
-    case SPV_REFLECT_FORMAT_R32G32B32A32_SINT   : return "VK_FORMAT_R32G32B32A32_SINT";
-    case SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT : return "VK_FORMAT_R32G32B32A32_SFLOAT";
-    case SPV_REFLECT_FORMAT_R64_UINT            : return "VK_FORMAT_R64_UINT";
-    case SPV_REFLECT_FORMAT_R64_SINT            : return "VK_FORMAT_R64_SINT";
-    case SPV_REFLECT_FORMAT_R64_SFLOAT          : return "VK_FORMAT_R64_SFLOAT";
-    case SPV_REFLECT_FORMAT_R64G64_UINT         : return "VK_FORMAT_R64G64_UINT";
-    case SPV_REFLECT_FORMAT_R64G64_SINT         : return "VK_FORMAT_R64G64_SINT";
-    case SPV_REFLECT_FORMAT_R64G64_SFLOAT       : return "VK_FORMAT_R64G64_SFLOAT";
-    case SPV_REFLECT_FORMAT_R64G64B64_UINT      : return "VK_FORMAT_R64G64B64_UINT";
-    case SPV_REFLECT_FORMAT_R64G64B64_SINT      : return "VK_FORMAT_R64G64B64_SINT";
-    case SPV_REFLECT_FORMAT_R64G64B64_SFLOAT    : return "VK_FORMAT_R64G64B64_SFLOAT";
-    case SPV_REFLECT_FORMAT_R64G64B64A64_UINT   : return "VK_FORMAT_R64G64B64A64_UINT";
-    case SPV_REFLECT_FORMAT_R64G64B64A64_SINT   : return "VK_FORMAT_R64G64B64A64_SINT";
-    case SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT : return "VK_FORMAT_R64G64B64A64_SFLOAT";
+  switch (fmt) {
+    case SPV_REFLECT_FORMAT_UNDEFINED:
+      return "VK_FORMAT_UNDEFINED";
+    case SPV_REFLECT_FORMAT_R32_UINT:
+      return "VK_FORMAT_R32_UINT";
+    case SPV_REFLECT_FORMAT_R32_SINT:
+      return "VK_FORMAT_R32_SINT";
+    case SPV_REFLECT_FORMAT_R32_SFLOAT:
+      return "VK_FORMAT_R32_SFLOAT";
+    case SPV_REFLECT_FORMAT_R32G32_UINT:
+      return "VK_FORMAT_R32G32_UINT";
+    case SPV_REFLECT_FORMAT_R32G32_SINT:
+      return "VK_FORMAT_R32G32_SINT";
+    case SPV_REFLECT_FORMAT_R32G32_SFLOAT:
+      return "VK_FORMAT_R32G32_SFLOAT";
+    case SPV_REFLECT_FORMAT_R32G32B32_UINT:
+      return "VK_FORMAT_R32G32B32_UINT";
+    case SPV_REFLECT_FORMAT_R32G32B32_SINT:
+      return "VK_FORMAT_R32G32B32_SINT";
+    case SPV_REFLECT_FORMAT_R32G32B32_SFLOAT:
+      return "VK_FORMAT_R32G32B32_SFLOAT";
+    case SPV_REFLECT_FORMAT_R32G32B32A32_UINT:
+      return "VK_FORMAT_R32G32B32A32_UINT";
+    case SPV_REFLECT_FORMAT_R32G32B32A32_SINT:
+      return "VK_FORMAT_R32G32B32A32_SINT";
+    case SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT:
+      return "VK_FORMAT_R32G32B32A32_SFLOAT";
+    case SPV_REFLECT_FORMAT_R64_UINT:
+      return "VK_FORMAT_R64_UINT";
+    case SPV_REFLECT_FORMAT_R64_SINT:
+      return "VK_FORMAT_R64_SINT";
+    case SPV_REFLECT_FORMAT_R64_SFLOAT:
+      return "VK_FORMAT_R64_SFLOAT";
+    case SPV_REFLECT_FORMAT_R64G64_UINT:
+      return "VK_FORMAT_R64G64_UINT";
+    case SPV_REFLECT_FORMAT_R64G64_SINT:
+      return "VK_FORMAT_R64G64_SINT";
+    case SPV_REFLECT_FORMAT_R64G64_SFLOAT:
+      return "VK_FORMAT_R64G64_SFLOAT";
+    case SPV_REFLECT_FORMAT_R64G64B64_UINT:
+      return "VK_FORMAT_R64G64B64_UINT";
+    case SPV_REFLECT_FORMAT_R64G64B64_SINT:
+      return "VK_FORMAT_R64G64B64_SINT";
+    case SPV_REFLECT_FORMAT_R64G64B64_SFLOAT:
+      return "VK_FORMAT_R64G64B64_SFLOAT";
+    case SPV_REFLECT_FORMAT_R64G64B64A64_UINT:
+      return "VK_FORMAT_R64G64B64A64_UINT";
+    case SPV_REFLECT_FORMAT_R64G64B64A64_SINT:
+      return "VK_FORMAT_R64G64B64A64_SINT";
+    case SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT:
+      return "VK_FORMAT_R64G64B64A64_SFLOAT";
   }
   // unhandled SpvReflectFormat enum value
   return "VK_FORMAT_???";
 }
 
-static std::string ToStringScalarType(const SpvReflectTypeDescription& type)
-{
-  switch(type.op) {
+static std::string ToStringScalarType(const SpvReflectTypeDescription& type) {
+  switch (type.op) {
     case SpvOpTypeVoid: {
       return "void";
       break;
@@ -502,62 +752,66 @@ static std::string ToStringScalarType(const SpvReflectTypeDescription& type)
   return "";
 }
 
-static std::string ToStringGlslType(const SpvReflectTypeDescription& type)
-{
+static std::string ToStringGlslType(const SpvReflectTypeDescription& type) {
   switch (type.op) {
     case SpvOpTypeVector: {
       switch (type.traits.numeric.scalar.width) {
         case 32: {
           switch (type.traits.numeric.vector.component_count) {
-          case 2: return "vec2";
-          case 3: return "vec3";
-          case 4: return "vec4";
+            case 2:
+              return "vec2";
+            case 3:
+              return "vec3";
+            case 4:
+              return "vec4";
           }
-        }
-        break;
+        } break;
 
         case 64: {
           switch (type.traits.numeric.vector.component_count) {
-          case 2: return "dvec2";
-          case 3: return "dvec3";
-          case 4: return "dvec4";
+            case 2:
+              return "dvec2";
+            case 3:
+              return "dvec3";
+            case 4:
+              return "dvec4";
           }
-        }
-        break;
+        } break;
       }
-    }
-    break;
+    } break;
     default:
       break;
   }
   return ToStringScalarType(type);
 }
 
-static std::string ToStringHlslType(const SpvReflectTypeDescription& type)
-{
+static std::string ToStringHlslType(const SpvReflectTypeDescription& type) {
   switch (type.op) {
     case SpvOpTypeVector: {
       switch (type.traits.numeric.scalar.width) {
         case 32: {
           switch (type.traits.numeric.vector.component_count) {
-          case 2: return "float2";
-          case 3: return "float3";
-          case 4: return "float4";
+            case 2:
+              return "float2";
+            case 3:
+              return "float3";
+            case 4:
+              return "float4";
           }
-        }
-        break;
+        } break;
 
         case 64: {
           switch (type.traits.numeric.vector.component_count) {
-          case 2: return "double2";
-          case 3: return "double3";
-          case 4: return "double4";
+            case 2:
+              return "double2";
+            case 3:
+              return "double3";
+            case 4:
+              return "double4";
           }
-        }
-        break;
+        } break;
       }
-    }
-    break;
+    } break;
 
     default:
       break;
@@ -565,8 +819,8 @@ static std::string ToStringHlslType(const SpvReflectTypeDescription& type)
   return ToStringScalarType(type);
 }
 
-std::string ToStringType(SpvSourceLanguage src_lang, const SpvReflectTypeDescription& type)
-{
+std::string ToStringType(SpvSourceLanguage src_lang,
+                         const SpvReflectTypeDescription& type) {
   if (src_lang == SpvSourceLanguageHLSL) {
     return ToStringHlslType(type);
   }
@@ -574,8 +828,8 @@ std::string ToStringType(SpvSourceLanguage src_lang, const SpvReflectTypeDescrip
   return ToStringGlslType(type);
 }
 
-std::string ToStringComponentType(const SpvReflectTypeDescription& type, uint32_t member_decoration_flags)
-{
+std::string ToStringComponentType(const SpvReflectTypeDescription& type,
+                                  uint32_t member_decoration_flags) {
   uint32_t masked_type = type.type_flags & 0xF;
   if (masked_type == 0) {
     return "";
@@ -585,34 +839,46 @@ std::string ToStringComponentType(const SpvReflectTypeDescription& type, uint32_
 
   if (type.type_flags & SPV_REFLECT_TYPE_FLAG_MATRIX) {
     if (member_decoration_flags & SPV_REFLECT_DECORATION_COLUMN_MAJOR) {
-      ss << "column_major" << " ";
-    }
-    else if (member_decoration_flags & SPV_REFLECT_DECORATION_ROW_MAJOR) {
-      ss << "row_major" << " ";
+      ss << "column_major"
+         << " ";
+    } else if (member_decoration_flags & SPV_REFLECT_DECORATION_ROW_MAJOR) {
+      ss << "row_major"
+         << " ";
     }
   }
 
   switch (masked_type) {
-    default: assert(false && "unsupported component type"); break;
-    case SPV_REFLECT_TYPE_FLAG_BOOL  : ss << "bool"; break;
-    case SPV_REFLECT_TYPE_FLAG_INT   : ss << (type.traits.numeric.scalar.signedness ? "int" : "uint"); break;
-    case SPV_REFLECT_TYPE_FLAG_FLOAT : ss << "float"; break;
+    default:
+      assert(false && "unsupported component type");
+      break;
+    case SPV_REFLECT_TYPE_FLAG_BOOL:
+      ss << "bool";
+      break;
+    case SPV_REFLECT_TYPE_FLAG_INT:
+      ss << (type.traits.numeric.scalar.signedness ? "int" : "uint");
+      break;
+    case SPV_REFLECT_TYPE_FLAG_FLOAT:
+      ss << "float";
+      break;
   }
 
   if (type.type_flags & SPV_REFLECT_TYPE_FLAG_MATRIX) {
     ss << type.traits.numeric.matrix.row_count;
     ss << "x";
     ss << type.traits.numeric.matrix.column_count;
-  }
-  else if (type.type_flags & SPV_REFLECT_TYPE_FLAG_VECTOR) {
+  } else if (type.type_flags & SPV_REFLECT_TYPE_FLAG_VECTOR) {
     ss << type.traits.numeric.vector.component_count;
   }
 
   return ss.str();
 }
 
-void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool flatten_cbuffers, const std::string& parent_name, uint32_t member_count, const SpvReflectBlockVariable* p_members, std::vector<TextLine>* p_text_lines)
-{
+void ParseBlockMembersToTextLines(const char* indent, int indent_depth,
+                                  bool flatten_cbuffers,
+                                  const std::string& parent_name,
+                                  uint32_t member_count,
+                                  const SpvReflectBlockVariable* p_members,
+                                  std::vector<TextLine>* p_text_lines) {
   const char* t = indent;
   for (uint32_t member_index = 0; member_index < member_count; ++member_index) {
     indent_depth = flatten_cbuffers ? 2 : indent_depth;
@@ -620,17 +886,21 @@ void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool fla
     for (int indent_count = 0; indent_count < indent_depth; ++indent_count) {
       ss_indent << t;
     }
-    std::string expanded_indent = ss_indent.str(); 
+    std::string expanded_indent = ss_indent.str();
 
     const auto& member = p_members[member_index];
-    bool is_struct = ((member.type_description->type_flags & static_cast<SpvReflectTypeFlags>(SPV_REFLECT_TYPE_FLAG_STRUCT)) != 0);
+    bool is_struct =
+        ((member.type_description->type_flags &
+          static_cast<SpvReflectTypeFlags>(SPV_REFLECT_TYPE_FLAG_STRUCT)) != 0);
     if (is_struct) {
       const std::string name = (member.name == nullptr ? "" : member.name);
 
       // Begin struct
       TextLine tl = {};
       tl.indent = expanded_indent;
-      tl.type_name = (member.type_description->type_name == nullptr ? "" : member.type_description->type_name);
+      tl.type_name = (member.type_description->type_name == nullptr
+                          ? ""
+                          : member.type_description->type_name);
       tl.absolute_offset = member.absolute_offset;
       tl.relative_offset = member.offset;
       tl.size = member.size;
@@ -646,37 +916,46 @@ void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool fla
       tl = {};
       std::string current_parent_name;
       if (flatten_cbuffers) {
-        current_parent_name = parent_name.empty() ? name : (parent_name + "." + name);
+        current_parent_name =
+            parent_name.empty() ? name : (parent_name + "." + name);
       }
-      std::vector<TextLine>* p_target_text_line = flatten_cbuffers ? p_text_lines : &tl.lines;
-      ParseBlockMembersToTextLines(t, indent_depth + 1, flatten_cbuffers, current_parent_name, member.member_count, member.members, p_target_text_line);
+      std::vector<TextLine>* p_target_text_line =
+          flatten_cbuffers ? p_text_lines : &tl.lines;
+      ParseBlockMembersToTextLines(t, indent_depth + 1, flatten_cbuffers,
+                                   current_parent_name, member.member_count,
+                                   member.members, p_target_text_line);
       tl.text_line_flags = TEXT_LINE_TYPE_LINES;
-      p_text_lines->push_back(tl);      
+      p_text_lines->push_back(tl);
 
       // End struct
       tl = {};
       tl.indent = expanded_indent;
       tl.name = name;
-      if ((member.array.dims_count > 0) || (member.type_description->traits.array.dims[0] > 0)) {
-        const SpvReflectArrayTraits* p_array_info = (member.array.dims_count > 0) ? &member.array : nullptr;
+      if ((member.array.dims_count > 0) ||
+          (member.type_description->traits.array.dims[0] > 0)) {
+        const SpvReflectArrayTraits* p_array_info =
+            (member.array.dims_count > 0) ? &member.array : nullptr;
         if (p_array_info == nullptr) {
           //
-          // glslang based compilers stores array information in the type and not the variable
+          // glslang based compilers stores array information in the type and
+          // not the variable
           //
-          p_array_info = (member.type_description->traits.array.dims[0] > 0) ? &member.type_description->traits.array : nullptr;
+          p_array_info = (member.type_description->traits.array.dims[0] > 0)
+                             ? &member.type_description->traits.array
+                             : nullptr;
         }
         if (p_array_info != nullptr) {
           std::stringstream ss_array;
-          for (uint32_t array_dim_index = 0; array_dim_index < p_array_info->dims_count; ++array_dim_index) {            
+          for (uint32_t array_dim_index = 0;
+               array_dim_index < p_array_info->dims_count; ++array_dim_index) {
             uint32_t dim = p_array_info->dims[array_dim_index];
-            // 
-            // dim = 0 means it's an unbounded array 
+            //
+            // dim = 0 means it's an unbounded array
             //
             if (dim > 0) {
-                ss_array << "[" << dim << "]";
-            }
-            else {
-                ss_array << "[]";
+              ss_array << "[" << dim << "]";
+            } else {
+              ss_array << "[]";
             }
           }
           tl.name += ss_array.str();
@@ -692,8 +971,7 @@ void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool fla
       if (!flatten_cbuffers) {
         p_text_lines->push_back(tl);
       }
-    }
-    else {
+    } else {
       std::string name = (member.name == nullptr ? "" : member.name);
       if (flatten_cbuffers) {
         if (!parent_name.empty()) {
@@ -703,11 +981,13 @@ void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool fla
 
       TextLine tl = {};
       tl.indent = expanded_indent;
-      tl.type_name = ToStringComponentType(*member.type_description, member.decoration_flags);
+      tl.type_name = ToStringComponentType(*member.type_description,
+                                           member.decoration_flags);
       tl.name = name;
       if (member.array.dims_count > 0) {
         std::stringstream ss_array;
-        for (uint32_t array_dim_index = 0; array_dim_index < member.array.dims_count; ++array_dim_index) {
+        for (uint32_t array_dim_index = 0;
+             array_dim_index < member.array.dims_count; ++array_dim_index) {
           uint32_t dim = member.array.dims[array_dim_index];
           ss_array << "[" << dim << "]";
         }
@@ -719,17 +999,20 @@ void ParseBlockMembersToTextLines(const char* indent, int indent_depth, bool fla
       tl.padded_size = member.padded_size;
       tl.array_stride = member.array.stride;
       tl.block_variable_flags = member.flags;
-      p_text_lines->push_back(tl);      
+      p_text_lines->push_back(tl);
     }
   }
 }
 
-void ParseBlockVariableToTextLines(const char* indent, bool flatten_cbuffers, const SpvReflectBlockVariable& block_var, std::vector<TextLine>* p_text_lines)
-{
+void ParseBlockVariableToTextLines(const char* indent, bool flatten_cbuffers,
+                                   const SpvReflectBlockVariable& block_var,
+                                   std::vector<TextLine>* p_text_lines) {
   // Begin block
   TextLine tl = {};
   tl.indent = indent;
-  tl.type_name = (block_var.type_description->type_name != nullptr) ? block_var.type_description->type_name : "<unnamed>";
+  tl.type_name = (block_var.type_description->type_name != nullptr)
+                     ? block_var.type_description->type_name
+                     : "<unnamed>";
   tl.size = block_var.size;
   tl.padded_size = block_var.padded_size;
   tl.text_line_flags = TEXT_LINE_TYPE_BLOCK_BEGIN;
@@ -737,9 +1020,11 @@ void ParseBlockVariableToTextLines(const char* indent, bool flatten_cbuffers, co
 
   // Members
   tl = {};
-  ParseBlockMembersToTextLines(indent, 2, flatten_cbuffers, "", block_var.member_count, block_var.members, &tl.lines);
+  ParseBlockMembersToTextLines(indent, 2, flatten_cbuffers, "",
+                               block_var.member_count, block_var.members,
+                               &tl.lines);
   tl.text_line_flags = TEXT_LINE_TYPE_LINES;
-  p_text_lines->push_back(tl);    
+  p_text_lines->push_back(tl);
 
   // End block
   tl = {};
@@ -753,8 +1038,9 @@ void ParseBlockVariableToTextLines(const char* indent, bool flatten_cbuffers, co
   p_text_lines->push_back(tl);
 }
 
-void FormatTextLines(const std::vector<TextLine>& text_lines, const char* indent, std::vector<TextLine>* p_formatted_lines)
-{
+void FormatTextLines(const std::vector<TextLine>& text_lines,
+                     const char* indent,
+                     std::vector<TextLine>* p_formatted_lines) {
   size_t modifier_width = 0;
   size_t type_name_width = 0;
   size_t name_width = 0;
@@ -775,30 +1061,29 @@ void FormatTextLines(const std::vector<TextLine>& text_lines, const char* indent
     auto& tl = text_lines[i];
 
     std::stringstream ss;
-    if ((tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_BEGIN) || (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_BEGIN)) {
+    if ((tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_BEGIN) ||
+        (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_BEGIN)) {
       ss << indent;
       ss << tl.indent;
       ss << "struct ";
       ss << tl.type_name;
       ss << " {";
-    }
-    else if ((tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_END) || (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_END)) {
+    } else if ((tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_END) ||
+               (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_END)) {
       ss << indent;
       ss << tl.indent;
       ss << "} ";
       ss << tl.name;
       ss << ";";
-    }
-    else if (tl.text_line_flags == TEXT_LINE_TYPE_LINES) {
+    } else if (tl.text_line_flags == TEXT_LINE_TYPE_LINES) {
       FormatTextLines(tl.lines, indent, p_formatted_lines);
-    }
-    else {
+    } else {
       ss << indent;
       ss << tl.indent;
       if (modifier_width > 0) {
         ss << std::setw(modifier_width) << std::left << tl.modifier;
         ss << " ";
-      }     
+      }
       ss << std::setw(type_name_width) << std::left << tl.type_name;
       ss << " ";
       ss << std::setw(name_width) << (tl.name + ";");
@@ -828,8 +1113,9 @@ void FormatTextLines(const std::vector<TextLine>& text_lines, const char* indent
   }
 }
 
-void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbuffers, const std::vector<TextLine>& text_lines)
-{
+void StreamWriteTextLines(std::ostream& os, const char* indent,
+                          bool flatten_cbuffers,
+                          const std::vector<TextLine>& text_lines) {
   std::vector<TextLine> formatted_lines;
   FormatTextLines(text_lines, indent, &formatted_lines);
 
@@ -846,11 +1132,15 @@ void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbu
       continue;
     }
     line_width = std::max<size_t>(line_width, tl.formatted_line.length());
-    absolute_offset_width = std::max<size_t>(absolute_offset_width, tl.formatted_absolute_offset.length());
-    offset_width = std::max<size_t>(offset_width, tl.formatted_relative_offset.length());
+    absolute_offset_width = std::max<size_t>(
+        absolute_offset_width, tl.formatted_absolute_offset.length());
+    offset_width =
+        std::max<size_t>(offset_width, tl.formatted_relative_offset.length());
     size_width = std::max<size_t>(size_width, tl.formatted_size.length());
-    padded_size_width = std::max<size_t>(padded_size_width, tl.formatted_padded_size.length());
-    array_stride_width = std::max<size_t>(array_stride_width, tl.formatted_array_stride.length());
+    padded_size_width =
+        std::max<size_t>(padded_size_width, tl.formatted_padded_size.length());
+    array_stride_width = std::max<size_t>(array_stride_width,
+                                          tl.formatted_array_stride.length());
   }
 
   size_t n = formatted_lines.size();
@@ -865,21 +1155,20 @@ void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbu
       size_t pos = tl.formatted_line.find_first_not_of(' ');
       if (pos != std::string::npos) {
         std::string s(pos, ' ');
-        os << s << "//" << " ";
+        os << s << "//"
+           << " ";
         os << "size = " << tl.formatted_size << ", ";
         os << "padded size = " << tl.formatted_padded_size;
         os << "\n";
       }
 
       os << std::setw(line_width) << std::left << tl.formatted_line;
-    }
-    else if (tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_END) {
+    } else if (tl.text_line_flags == TEXT_LINE_TYPE_BLOCK_END) {
       os << std::setw(line_width) << std::left << tl.formatted_line;
       if (i < (n - 1)) {
         os << "\n";
       }
-    }
-    else if (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_BEGIN) {
+    } else if (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_BEGIN) {
       if (!flatten_cbuffers) {
         if (i > 0) {
           os << "\n";
@@ -888,7 +1177,8 @@ void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbu
         size_t pos = tl.formatted_line.find_first_not_of(' ');
         if (pos != std::string::npos) {
           std::string s(pos, ' ');
-          os << s << "//" << " ";
+          os << s << "//"
+             << " ";
           os << "abs offset = " << tl.formatted_absolute_offset << ", ";
           os << "rel offset = " << tl.formatted_relative_offset << ", ";
           os << "size = " << tl.formatted_size << ", ";
@@ -906,27 +1196,32 @@ void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbu
 
         os << std::setw(line_width) << std::left << tl.formatted_line;
       }
-    }
-    else if (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_END) {
+    } else if (tl.text_line_flags == TEXT_LINE_TYPE_STRUCT_END) {
       if (!flatten_cbuffers) {
         os << std::setw(line_width) << std::left << tl.formatted_line;
         if (i < (n - 1)) {
           os << "\n";
         }
       }
-    }
-    else {
+    } else {
       os << std::setw(line_width) << std::left << tl.formatted_line;
-      os << " " << "//" << " ";
-      os << "abs offset = " << std::setw(absolute_offset_width) << std::right << tl.formatted_absolute_offset << ", ";
+      os << " "
+         << "//"
+         << " ";
+      os << "abs offset = " << std::setw(absolute_offset_width) << std::right
+         << tl.formatted_absolute_offset << ", ";
       if (!flatten_cbuffers) {
-        os << "rel offset = " << std::setw(offset_width) << std::right << tl.formatted_relative_offset << ", ";
+        os << "rel offset = " << std::setw(offset_width) << std::right
+           << tl.formatted_relative_offset << ", ";
       }
-      os << "size = " << std::setw(size_width) << std::right << tl.formatted_size << ", ";
-      os << "padded size = " << std::setw(padded_size_width) << std::right << tl.formatted_padded_size;
+      os << "size = " << std::setw(size_width) << std::right
+         << tl.formatted_size << ", ";
+      os << "padded size = " << std::setw(padded_size_width) << std::right
+         << tl.formatted_padded_size;
       if (tl.array_stride > 0) {
         os << ", ";
-        os << "array stride = " << std::setw(array_stride_width) << tl.formatted_array_stride;
+        os << "array stride = " << std::setw(array_stride_width)
+           << tl.formatted_array_stride;
       }
       if (!tl.formatted_block_variable_flags.empty()) {
         os << " ";
@@ -940,18 +1235,21 @@ void StreamWriteTextLines(std::ostream& os, const char* indent, bool flatten_cbu
   }
 }
 
-void StreamWritePushConstantsBlock(std::ostream& os, const SpvReflectBlockVariable& obj, bool flatten_cbuffers, const char* indent)
-{
+void StreamWritePushConstantsBlock(std::ostream& os,
+                                   const SpvReflectBlockVariable& obj,
+                                   bool flatten_cbuffers, const char* indent) {
   const char* t = indent;
   os << t << "spirv id : " << obj.spirv_id << "\n";
-  
+
   os << t << "name     : " << ((obj.name != nullptr) ? obj.name : "<unnamed>");
-  if ((obj.type_description->type_name != nullptr) && (strlen(obj.type_description->type_name) > 0)) {
-    os << " " << "(" << obj.type_description->type_name << ")";
+  if ((obj.type_description->type_name != nullptr) &&
+      (strlen(obj.type_description->type_name) > 0)) {
+    os << " "
+       << "(" << obj.type_description->type_name << ")";
   }
 
   std::vector<TextLine> text_lines;
-  ParseBlockVariableToTextLines("    ",  flatten_cbuffers, obj, &text_lines);
+  ParseBlockVariableToTextLines("    ", flatten_cbuffers, obj, &text_lines);
   if (!text_lines.empty()) {
     os << "\n";
     StreamWriteTextLines(os, t, flatten_cbuffers, text_lines);
@@ -959,8 +1257,10 @@ void StreamWritePushConstantsBlock(std::ostream& os, const SpvReflectBlockVariab
   }
 }
 
-void StreamWriteDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBinding& obj, bool write_set, bool flatten_cbuffers, const char* indent)
-{
+void StreamWriteDescriptorBinding(std::ostream& os,
+                                  const SpvReflectDescriptorBinding& obj,
+                                  bool write_set, bool flatten_cbuffers,
+                                  const char* indent) {
   const char* t = indent;
   os << t << "spirv id : " << obj.spirv_id << "\n";
   if (write_set) {
@@ -968,15 +1268,18 @@ void StreamWriteDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBi
   }
   os << t << "binding  : " << obj.binding << "\n";
   os << t << "type     : " << ToStringDescriptorType(obj.descriptor_type);
-  os << " " << "(" << ToStringResourceType(obj.resource_type) << ")" << "\n";
+  os << " "
+     << "(" << ToStringResourceType(obj.resource_type) << ")"
+     << "\n";
 
   // count
   os << t << "count    : " << obj.count << "\n";
 
   // array
-  if (obj.array.dims_count > 0) {  
+  if (obj.array.dims_count > 0) {
     os << t << "array    : ";
-    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count; ++dim_index) {
+    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count;
+         ++dim_index) {
       os << "[" << obj.array.dims[dim_index] << "]";
     }
     os << "\n";
@@ -994,17 +1297,20 @@ void StreamWriteDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBi
   }
 
   // accessed
-  os << t << "accessed : " << (obj.accessed? "true" : "false") << "\n";
+  os << t << "accessed : " << (obj.accessed ? "true" : "false") << "\n";
 
   os << t << "name     : " << ((obj.name != nullptr) ? obj.name : "<unnamed>");
-  if ((obj.type_description->type_name != nullptr) && (strlen(obj.type_description->type_name) > 0)) {
-    os << " " << "(" << obj.type_description->type_name << ")";
+  if ((obj.type_description->type_name != nullptr) &&
+      (strlen(obj.type_description->type_name) > 0)) {
+    os << " "
+       << "(" << obj.type_description->type_name << ")";
   }
 
   if (obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
       obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
     std::vector<TextLine> text_lines;
-    ParseBlockVariableToTextLines("    ",  flatten_cbuffers, obj.block, &text_lines);
+    ParseBlockVariableToTextLines("    ", flatten_cbuffers, obj.block,
+                                  &text_lines);
     if (!text_lines.empty()) {
       os << "\n";
       StreamWriteTextLines(os, t, flatten_cbuffers, text_lines);
@@ -1013,72 +1319,82 @@ void StreamWriteDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBi
   }
 }
 
-void StreamWriteInterfaceVariable(std::ostream& os, const SpvReflectInterfaceVariable& obj, const char* indent)
-{
+void StreamWriteInterfaceVariable(std::ostream& os,
+                                  const SpvReflectInterfaceVariable& obj,
+                                  const char* indent) {
   const char* t = indent;
   os << t << "spirv id  : " << obj.spirv_id << "\n";
   os << t << "location  : ";
   if (obj.decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) {
-    os << "(built-in)" << " ";
+    os << "(built-in)"
+       << " ";
     os << ToStringSpvBuiltIn(obj.built_in);
-  }
-  else {
+  } else {
     os << obj.location;
   }
   os << "\n";
-  os << t << "type      : " << ToStringComponentType(*obj.type_description, 0) << "\n";
+  os << t << "type      : " << ToStringComponentType(*obj.type_description, 0)
+     << "\n";
 
   // array
-  if (obj.array.dims_count > 0) {  
+  if (obj.array.dims_count > 0) {
     os << t << "array     : ";
-    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count; ++dim_index) {
+    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count;
+         ++dim_index) {
       os << "[" << obj.array.dims[dim_index] << "]";
     }
     os << "\n";
   }
 
-  os << t << "semantic  : " << (obj.semantic != NULL ? obj.semantic : "") << "\n";
+  os << t << "semantic  : " << (obj.semantic != NULL ? obj.semantic : "")
+     << "\n";
   os << t << "name      : " << (obj.name != NULL ? obj.name : "");
-  if ((obj.type_description->type_name != nullptr) && (strlen(obj.type_description->type_name) > 0)) {
-    os << " " << "(" << obj.type_description->type_name << ")";
+  if ((obj.type_description->type_name != nullptr) &&
+      (strlen(obj.type_description->type_name) > 0)) {
+    os << " "
+       << "(" << obj.type_description->type_name << ")";
   }
   os << "\n";
   os << t << "qualifier : ";
   if (obj.decoration_flags & SPV_REFLECT_DECORATION_FLAT) {
     os << "flat";
-  }
-  else   if (obj.decoration_flags & SPV_REFLECT_DECORATION_NOPERSPECTIVE) {
+  } else if (obj.decoration_flags & SPV_REFLECT_DECORATION_NOPERSPECTIVE) {
     os << "noperspective";
   }
 }
 
-void StreamWriteEntryPoint(std::ostream& os, const SpvReflectEntryPoint& obj, const char* indent)
-{
+void StreamWriteEntryPoint(std::ostream& os, const SpvReflectEntryPoint& obj,
+                           const char* indent) {
   os << indent << "entry point     : " << obj.name;
   os << " (stage=" << ToStringShaderStage(obj.shader_stage) << ")";
   if (obj.shader_stage == SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT) {
     os << "\n";
-    os << "local size      : " << "(" << obj.local_size.x << ", " << obj.local_size.y << ", " << obj.local_size.z << ")";
+    os << "local size      : "
+       << "(" << obj.local_size.x << ", " << obj.local_size.y << ", "
+       << obj.local_size.z << ")";
   }
 }
 
-void StreamWriteShaderModule(std::ostream& os, const SpvReflectShaderModule& obj, const char* indent)
-{
+void StreamWriteShaderModule(std::ostream& os,
+                             const SpvReflectShaderModule& obj,
+                             const char* indent) {
   (void)indent;
   os << "generator       : " << ToStringGenerator(obj.generator) << "\n";
-  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language) << "\n";
+  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language)
+     << "\n";
   os << "source lang ver : " << obj.source_language_version << "\n";
-  os << "source file     : " << (obj.source_file != NULL ? obj.source_file : "") << "\n";
-  //os << "shader stage    : " << ToStringShaderStage(obj.shader_stage) << "\n";
+  os << "source file     : " << (obj.source_file != NULL ? obj.source_file : "")
+     << "\n";
+  // os << "shader stage    : " << ToStringShaderStage(obj.shader_stage) <<
+  // "\n";
 
   for (uint32_t i = 0; i < obj.entry_point_count; ++i) {
     StreamWriteEntryPoint(os, obj.entry_points[i], "");
     if (i < (obj.entry_point_count - 1)) {
-        os << "\n";
+      os << "\n";
     }
   }
 }
-
 
 // Avoid unused variable warning/error on Linux
 #ifndef NDEBUG
@@ -1087,11 +1403,11 @@ void StreamWriteShaderModule(std::ostream& os, const SpvReflectShaderModule& obj
 #define USE_ASSERT(x) ((void)(x))
 #endif
 
-void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers, std::ostream& os)
-{
-  const char* t     = "  ";
-  const char* tt    = "    ";
-  const char* ttt   = "      ";
+void WriteReflection(const spv_reflect::ShaderModule& obj,
+                     bool flatten_cbuffers, std::ostream& os) {
+  const char* t = "  ";
+  const char* tt = "    ";
+  const char* ttt = "      ";
 
   StreamWriteShaderModule(os, obj.GetShaderModule(), "");
 
@@ -1115,11 +1431,12 @@ void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers
     for (size_t i = 0; i < variables.size(); ++i) {
       auto p_var = variables[i];
       USE_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
-      os << tt << i << ":" << "\n";
+      os << tt << i << ":"
+         << "\n";
       StreamWriteInterfaceVariable(os, *p_var, ttt);
       if (i < (count - 1)) {
         os << "\n";
-      }  
+      }
     }
   }
 
@@ -1137,11 +1454,12 @@ void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers
     for (size_t i = 0; i < variables.size(); ++i) {
       auto p_var = variables[i];
       USE_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
-      os << tt << i << ":" << "\n";
+      os << tt << i << ":"
+         << "\n";
       StreamWriteInterfaceVariable(os, *p_var, ttt);
       if (i < (count - 1)) {
         os << "\n";
-      }  
+      }
     }
   }
 
@@ -1158,11 +1476,11 @@ void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers
     os << t << "Push constant blocks: " << count << "\n\n";
     for (size_t i = 0; i < push_constant_bocks.size(); ++i) {
       auto p_block = push_constant_bocks[i];
-      os << tt << i << ":" << "\n";
+      os << tt << i << ":"
+         << "\n";
       StreamWritePushConstantsBlock(os, *p_block, flatten_cbuffers, ttt);
     }
   }
-
 
   count = 0;
   result = obj.EnumerateDescriptorBindings(&count, nullptr);
@@ -1171,7 +1489,8 @@ void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers
   result = obj.EnumerateDescriptorBindings(&count, bindings.data());
   USE_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
   std::sort(std::begin(bindings), std::end(bindings),
-            [](SpvReflectDescriptorBinding* a, SpvReflectDescriptorBinding* b) -> bool {
+            [](SpvReflectDescriptorBinding* a,
+               SpvReflectDescriptorBinding* b) -> bool {
               if (a->set != b->set) {
                 return a->set < b->set;
               }
@@ -1185,37 +1504,42 @@ void WriteReflection(const spv_reflect::ShaderModule& obj, bool flatten_cbuffers
     for (size_t i = 0; i < bindings.size(); ++i) {
       auto p_binding = bindings[i];
       USE_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
-      os << tt << "Binding" << " " << p_binding->set << "." << p_binding->binding << "" << "\n";
+      os << tt << "Binding"
+         << " " << p_binding->set << "." << p_binding->binding << ""
+         << "\n";
       StreamWriteDescriptorBinding(os, *p_binding, true, flatten_cbuffers, ttt);
       if (i < (count - 1)) {
         os << "\n\n";
-      }  
+      }
     }
   }
 }
 
 //////////////////////////////////
 
-SpvReflectToYaml::SpvReflectToYaml(const SpvReflectShaderModule& shader_module, uint32_t verbosity) :
-  sm_(shader_module), verbosity_(verbosity)
-{
-}
+SpvReflectToYaml::SpvReflectToYaml(const SpvReflectShaderModule& shader_module,
+                                   uint32_t verbosity)
+    : sm_(shader_module), verbosity_(verbosity) {}
 
-void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTypeDescription& td, uint32_t indent_level) {
-  // YAML anchors can only refer to points earlier in the doc, so child type descriptions must
-  // be processed before the parent.
-  for(uint32_t i=0; i<td.member_count; ++i) {
+void SpvReflectToYaml::WriteTypeDescription(std::ostream& os,
+                                            const SpvReflectTypeDescription& td,
+                                            uint32_t indent_level) {
+  // YAML anchors can only refer to points earlier in the doc, so child type
+  // descriptions must be processed before the parent.
+  for (uint32_t i = 0; i < td.member_count; ++i) {
     WriteTypeDescription(os, td.members[i], indent_level);
   }
   const std::string t0 = Indent(indent_level);
-  const std::string t1 = Indent(indent_level+1);
-  const std::string t2 = Indent(indent_level+2);
-  const std::string t3 = Indent(indent_level+3);
-  const std::string t4 = Indent(indent_level+4);
+  const std::string t1 = Indent(indent_level + 1);
+  const std::string t2 = Indent(indent_level + 2);
+  const std::string t3 = Indent(indent_level + 3);
+  const std::string t4 = Indent(indent_level + 4);
 
   // Determine the index of this type within the shader module's list.
-  assert(type_description_to_index_.find(&td) == type_description_to_index_.end());
-  uint32_t type_description_index = static_cast<uint32_t>(type_description_to_index_.size());
+  assert(type_description_to_index_.find(&td) ==
+         type_description_to_index_.end());
+  uint32_t type_description_index =
+      static_cast<uint32_t>(type_description_to_index_.size());
   type_description_to_index_[&td] = type_description_index;
 
   os << t0 << "- &td" << type_description_index << std::endl;
@@ -1227,13 +1551,17 @@ void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTy
   //   const char*                       type_name;
   os << t1 << "type_name: " << SafeString(td.type_name) << std::endl;
   //   const char*                       struct_member_name;
-  os << t1 << "struct_member_name: " << SafeString(td.struct_member_name) << std::endl;
+  os << t1 << "struct_member_name: " << SafeString(td.struct_member_name)
+     << std::endl;
   //   SpvStorageClass                   storage_class;
-  os << t1 << "storage_class: " << td.storage_class << " # " << ToStringSpvStorageClass(td.storage_class) << std::endl;
+  os << t1 << "storage_class: " << td.storage_class << " # "
+     << ToStringSpvStorageClass(td.storage_class) << std::endl;
   //   SpvReflectTypeFlags               type_flags;
-  os << t1 << "type_flags: " << AsHexString(td.type_flags) << " # " << ToStringTypeFlags(td.type_flags) << std::endl;
+  os << t1 << "type_flags: " << AsHexString(td.type_flags) << " # "
+     << ToStringTypeFlags(td.type_flags) << std::endl;
   //   SpvReflectDecorationFlags         decoration_flags;
-  os << t1 << "decoration_flags: " << AsHexString(td.decoration_flags) << " # " << ToStringDecorationFlags(td.decoration_flags) << std::endl;
+  os << t1 << "decoration_flags: " << AsHexString(td.decoration_flags) << " # "
+     << ToStringDecorationFlags(td.decoration_flags) << std::endl;
   //   struct Traits {
   os << t1 << "traits:" << std::endl;
   //     SpvReflectNumericTraits         numeric;
@@ -1260,7 +1588,8 @@ void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTy
   //   } matrix;
   os << t3 << "matrix: { ";
   os << "column_count: " << td.traits.numeric.matrix.column_count << ", ";
-  os << "row_count: " << td.traits.numeric.matrix.row_count << ", ";;
+  os << "row_count: " << td.traits.numeric.matrix.row_count << ", ";
+  ;
   os << "stride: " << td.traits.numeric.matrix.stride;
   os << " }" << std::endl;
   // } SpvReflectNumericTraits;
@@ -1281,7 +1610,10 @@ void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTy
   //   SpvImageFormat                    image_format;
   os << "image_format: " << td.traits.image.image_format;
   // } SpvReflectImageTraits;
-  os << " }" << " # dim=" << ToStringSpvDim(td.traits.image.dim) << " image_format=" << ToStringSpvImageFormat(td.traits.image.image_format) << std::endl;
+  os << " }"
+     << " # dim=" << ToStringSpvDim(td.traits.image.dim)
+     << " image_format=" << ToStringSpvImageFormat(td.traits.image.image_format)
+     << std::endl;
 
   //     SpvReflectArrayTraits           array;
   os << t2 << "array: { ";
@@ -1290,7 +1622,7 @@ void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTy
   os << "dims_count: " << td.traits.array.dims_count << ", ";
   //   uint32_t                          dims[SPV_REFLECT_MAX_ARRAY_DIMS];
   os << "dims: [";
-  for(uint32_t i_dim=0; i_dim < td.traits.array.dims_count; ++i_dim) {
+  for (uint32_t i_dim = 0; i_dim < td.traits.array.dims_count; ++i_dim) {
     os << td.traits.array.dims[i_dim] << ",";
   }
   os << "], ";
@@ -1304,24 +1636,28 @@ void SpvReflectToYaml::WriteTypeDescription(std::ostream& os, const SpvReflectTy
   os << t1 << "member_count: " << td.member_count << std::endl;
   //   struct SpvReflectTypeDescription* members;
   os << t1 << "members:" << std::endl;
-  for(uint32_t i_member=0; i_member < td.member_count; ++i_member) {
-    os << t2 << "- *td" << type_description_to_index_[&(td.members[i_member])] << std::endl;
+  for (uint32_t i_member = 0; i_member < td.member_count; ++i_member) {
+    os << t2 << "- *td" << type_description_to_index_[&(td.members[i_member])]
+       << std::endl;
   }
   // } SpvReflectTypeDescription;
 }
 
-void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBlockVariable& bv, uint32_t indent_level) {
-  for(uint32_t i=0; i<bv.member_count; ++i) {
+void SpvReflectToYaml::WriteBlockVariable(std::ostream& os,
+                                          const SpvReflectBlockVariable& bv,
+                                          uint32_t indent_level) {
+  for (uint32_t i = 0; i < bv.member_count; ++i) {
     WriteBlockVariable(os, bv.members[i], indent_level);
   }
 
   const std::string t0 = Indent(indent_level);
-  const std::string t1 = Indent(indent_level+1);
-  const std::string t2 = Indent(indent_level+2);
-  const std::string t3 = Indent(indent_level+3);
+  const std::string t1 = Indent(indent_level + 1);
+  const std::string t2 = Indent(indent_level + 2);
+  const std::string t3 = Indent(indent_level + 3);
 
   assert(block_variable_to_index_.find(&bv) == block_variable_to_index_.end());
-  uint32_t block_variable_index = static_cast<uint32_t>(block_variable_to_index_.size());
+  uint32_t block_variable_index =
+      static_cast<uint32_t>(block_variable_to_index_.size());
   block_variable_to_index_[&bv] = block_variable_index;
 
   os << t0 << "- &bv" << block_variable_index << std::endl;
@@ -1337,7 +1673,8 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   //   uint32_t                          padded_size;      // Measured in bytes
   os << t1 << "padded_size: " << bv.padded_size << std::endl;
   //   SpvReflectDecorationFlags         decoration_flags;
-  os << t1 << "decorations: " << AsHexString(bv.decoration_flags) << " # " << ToStringDecorationFlags(bv.decoration_flags) << std::endl;
+  os << t1 << "decorations: " << AsHexString(bv.decoration_flags) << " # "
+     << ToStringDecorationFlags(bv.decoration_flags) << std::endl;
   //   SpvReflectNumericTraits           numeric;
   // typedef struct SpvReflectNumericTraits {
   os << t1 << "numeric:" << std::endl;
@@ -1352,7 +1689,8 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   //     uint32_t                        component_count;
   //   } vector;
   os << t2 << "vector: { ";
-  os << "component_count: " << bv.numeric.vector.component_count << " }" << std::endl;
+  os << "component_count: " << bv.numeric.vector.component_count << " }"
+     << std::endl;
   //   struct Matrix {
   //     uint32_t                        column_count;
   //     uint32_t                        row_count;
@@ -1360,7 +1698,8 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   //   } matrix;
   os << t2 << "matrix: { ";
   os << "column_count: " << bv.numeric.matrix.column_count << ", ";
-  os << "row_count: " << bv.numeric.matrix.row_count << ", ";;
+  os << "row_count: " << bv.numeric.matrix.row_count << ", ";
+  ;
   os << "stride: " << bv.numeric.matrix.stride << " }" << std::endl;
   // } SpvReflectNumericTraits;
 
@@ -1371,7 +1710,7 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   os << "dims_count: " << bv.array.dims_count << ", ";
   //   uint32_t                          dims[SPV_REFLECT_MAX_ARRAY_DIMS];
   os << "dims: [";
-  for(uint32_t i_dim=0; i_dim < bv.array.dims_count; ++i_dim) {
+  for (uint32_t i_dim = 0; i_dim < bv.array.dims_count; ++i_dim) {
     os << bv.array.dims[i_dim] << ",";
   }
   os << "], ";
@@ -1384,7 +1723,7 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   os << t1 << "member_count: " << bv.member_count << std::endl;
   //   struct SpvReflectBlockVariable*   members;
   os << t1 << "members:" << std::endl;
-  for(uint32_t i=0; i<bv.member_count; ++i) {
+  for (uint32_t i = 0; i < bv.member_count; ++i) {
     auto itor = block_variable_to_index_.find(&bv.members[i]);
     assert(itor != block_variable_to_index_.end());
     os << t2 << "- *bv" << itor->second << std::endl;
@@ -1402,7 +1741,9 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   // } SpvReflectBlockVariable;
 }
 
-void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBinding& db, uint32_t indent_level) {
+void SpvReflectToYaml::WriteDescriptorBinding(
+    std::ostream& os, const SpvReflectDescriptorBinding& db,
+    uint32_t indent_level) {
   if (db.uav_counter_binding != nullptr) {
     auto itor = descriptor_binding_to_index_.find(db.uav_counter_binding);
     if (itor == descriptor_binding_to_index_.end()) {
@@ -1411,13 +1752,13 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   }
 
   const std::string t0 = Indent(indent_level);
-  const std::string t1 = Indent(indent_level+1);
-  const std::string t2 = Indent(indent_level+2);
-  const std::string t3 = Indent(indent_level+3);
+  const std::string t1 = Indent(indent_level + 1);
+  const std::string t2 = Indent(indent_level + 2);
+  const std::string t3 = Indent(indent_level + 3);
 
-  // A binding's UAV binding later may appear later in the table than the binding itself,
-  // in which case we've already output entries for both bindings, and can just write another
-  // reference here.
+  // A binding's UAV binding later may appear later in the table than the
+  // binding itself, in which case we've already output entries for both
+  // bindings, and can just write another reference here.
   {
     auto itor = descriptor_binding_to_index_.find(&db);
     if (itor != descriptor_binding_to_index_.end()) {
@@ -1426,7 +1767,8 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
     }
   }
 
-  uint32_t descriptor_binding_index = static_cast<uint32_t>(descriptor_binding_to_index_.size());
+  uint32_t descriptor_binding_index =
+      static_cast<uint32_t>(descriptor_binding_to_index_.size());
   descriptor_binding_to_index_[&db] = descriptor_binding_index;
 
   os << t0 << "- &db" << descriptor_binding_index << std::endl;
@@ -1438,13 +1780,16 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   //   uint32_t                            binding;
   os << t1 << "binding: " << db.binding << std::endl;
   //   uint32_t                            input_attachment_index;
-  os << t1 << "input_attachment_index: " << db.input_attachment_index << std::endl;
+  os << t1 << "input_attachment_index: " << db.input_attachment_index
+     << std::endl;
   //   uint32_t                            set;
   os << t1 << "set: " << db.set << std::endl;
   //   SpvReflectDescriptorType            descriptor_type;
-  os << t1 << "descriptor_type: " << db.descriptor_type << " # " << ToStringDescriptorType(db.descriptor_type) << std::endl;
+  os << t1 << "descriptor_type: " << db.descriptor_type << " # "
+     << ToStringDescriptorType(db.descriptor_type) << std::endl;
   //   SpvReflectResourceType              resource_type;
-  os << t1 << "resource_type: " << db.resource_type << " # " << ToStringResourceType(db.resource_type) << std::endl;
+  os << t1 << "resource_type: " << db.resource_type << " # "
+     << ToStringResourceType(db.resource_type) << std::endl;
   //   SpvReflectImageTraits           image;
   os << t1 << "image: { ";
   // typedef struct SpvReflectImageTraits {
@@ -1461,13 +1806,17 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   //   SpvImageFormat                    image_format;
   os << "image_format: " << db.image.image_format;
   // } SpvReflectImageTraits;
-  os << " }" << " # dim=" << ToStringSpvDim(db.image.dim) << " image_format=" << ToStringSpvImageFormat(db.image.image_format) << std::endl;
+  os << " }"
+     << " # dim=" << ToStringSpvDim(db.image.dim)
+     << " image_format=" << ToStringSpvImageFormat(db.image.image_format)
+     << std::endl;
 
   //   SpvReflectBlockVariable             block;
   {
     auto itor = block_variable_to_index_.find(&db.block);
     assert(itor != block_variable_to_index_.end());
-    os << t1 << "block: *bv" << itor->second << " # " << SafeString(db.block.name) << std::endl;
+    os << t1 << "block: *bv" << itor->second << " # "
+       << SafeString(db.block.name) << std::endl;
   }
   //   SpvReflectBindingArrayTraits        array;
   os << t1 << "array: { ";
@@ -1476,7 +1825,7 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   os << "dims_count: " << db.array.dims_count << ", ";
   //   uint32_t                          dims[SPV_REFLECT_MAX_ARRAY_DIMS];
   os << "dims: [";
-  for(uint32_t i_dim=0; i_dim < db.array.dims_count; ++i_dim) {
+  for (uint32_t i_dim = 0; i_dim < db.array.dims_count; ++i_dim) {
     os << db.array.dims[i_dim] << ",";
   }
   // } SpvReflectBindingArrayTraits;
@@ -1493,7 +1842,8 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   } else {
     auto itor = descriptor_binding_to_index_.find(db.uav_counter_binding);
     assert(itor != descriptor_binding_to_index_.end());
-    os << t1 << "uav_counter_binding: *db" << itor->second << " # " << SafeString(db.uav_counter_binding->name) << std::endl;
+    os << t1 << "uav_counter_binding: *db" << itor->second << " # "
+       << SafeString(db.uav_counter_binding->name) << std::endl;
   }
   if (verbosity_ >= 1) {
     //   SpvReflectTypeDescription*        type_description;
@@ -1514,18 +1864,22 @@ void SpvReflectToYaml::WriteDescriptorBinding(std::ostream& os, const SpvReflect
   // } SpvReflectDescriptorBinding;
 }
 
-void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflectInterfaceVariable& iv, uint32_t indent_level) {
-  for(uint32_t i=0; i<iv.member_count; ++i) {
-    assert(interface_variable_to_index_.find(&iv.members[i]) == interface_variable_to_index_.end());
+void SpvReflectToYaml::WriteInterfaceVariable(
+    std::ostream& os, const SpvReflectInterfaceVariable& iv,
+    uint32_t indent_level) {
+  for (uint32_t i = 0; i < iv.member_count; ++i) {
+    assert(interface_variable_to_index_.find(&iv.members[i]) ==
+           interface_variable_to_index_.end());
     WriteInterfaceVariable(os, iv.members[i], indent_level);
   }
 
   const std::string t0 = Indent(indent_level);
-  const std::string t1 = Indent(indent_level+1);
-  const std::string t2 = Indent(indent_level+2);
-  const std::string t3 = Indent(indent_level+3);
+  const std::string t1 = Indent(indent_level + 1);
+  const std::string t2 = Indent(indent_level + 2);
+  const std::string t3 = Indent(indent_level + 3);
 
-  uint32_t interface_variable_index = static_cast<uint32_t>(interface_variable_to_index_.size());
+  uint32_t interface_variable_index =
+      static_cast<uint32_t>(interface_variable_to_index_.size());
   interface_variable_to_index_[&iv] = interface_variable_index;
 
   // typedef struct SpvReflectInterfaceVariable {
@@ -1537,13 +1891,16 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   //   uint32_t                            location;
   os << t1 << "location: " << iv.location << std::endl;
   //   SpvStorageClass                     storage_class;
-  os << t1 << "storage_class: " << iv.storage_class << " # " << ToStringSpvStorageClass(iv.storage_class) << std::endl;
+  os << t1 << "storage_class: " << iv.storage_class << " # "
+     << ToStringSpvStorageClass(iv.storage_class) << std::endl;
   //   const char*                         semantic;
   os << t1 << "semantic: " << SafeString(iv.semantic) << std::endl;
   //   SpvReflectDecorationFlags           decoration_flags;
-  os << t1 << "decoration_flags: " << AsHexString(iv.decoration_flags) << " # " << ToStringDecorationFlags(iv.decoration_flags)  << std::endl;
+  os << t1 << "decoration_flags: " << AsHexString(iv.decoration_flags) << " # "
+     << ToStringDecorationFlags(iv.decoration_flags) << std::endl;
   //   SpvBuiltIn                          built_in;
-  os << t1 << "built_in: " << iv.built_in << " # " << ToStringSpvBuiltIn(iv.built_in) << std::endl;
+  os << t1 << "built_in: " << iv.built_in << " # "
+     << ToStringSpvBuiltIn(iv.built_in) << std::endl;
   //   SpvReflectNumericTraits             numeric;
   // typedef struct SpvReflectNumericTraits {
   os << t1 << "numeric:" << std::endl;
@@ -1558,7 +1915,8 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   //     uint32_t                        component_count;
   //   } vector;
   os << t2 << "vector: { ";
-  os << "component_count: " << iv.numeric.vector.component_count << " }" << std::endl;
+  os << "component_count: " << iv.numeric.vector.component_count << " }"
+     << std::endl;
   //   struct Matrix {
   //     uint32_t                        column_count;
   //     uint32_t                        row_count;
@@ -1566,7 +1924,8 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   //   } matrix;
   os << t2 << "matrix: { ";
   os << "column_count: " << iv.numeric.matrix.column_count << ", ";
-  os << "row_count: " << iv.numeric.matrix.row_count << ", ";;
+  os << "row_count: " << iv.numeric.matrix.row_count << ", ";
+  ;
   os << "stride: " << iv.numeric.matrix.stride << " }" << std::endl;
   // } SpvReflectNumericTraits;
 
@@ -1577,7 +1936,7 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   os << "dims_count: " << iv.array.dims_count << ", ";
   //   uint32_t                          dims[SPV_REFLECT_MAX_ARRAY_DIMS];
   os << "dims: [";
-  for(uint32_t i_dim=0; i_dim < iv.array.dims_count; ++i_dim) {
+  for (uint32_t i_dim = 0; i_dim < iv.array.dims_count; ++i_dim) {
     os << iv.array.dims[i_dim] << ",";
   }
   os << "], ";
@@ -1590,14 +1949,16 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   os << t1 << "member_count: " << iv.member_count << std::endl;
   //   struct SpvReflectInterfaceVariable* members;
   os << t1 << "members:" << std::endl;
-  for(uint32_t i=0; i<iv.member_count; ++i) {
+  for (uint32_t i = 0; i < iv.member_count; ++i) {
     auto itor = interface_variable_to_index_.find(&iv.members[i]);
     assert(itor != interface_variable_to_index_.end());
-    os << t2 << "- *iv" << itor->second << " # " << SafeString(iv.members[i].name) << std::endl;
+    os << t2 << "- *iv" << itor->second << " # "
+       << SafeString(iv.members[i].name) << std::endl;
   }
 
   //   SpvReflectFormat                    format;
-  os << t1 << "format: " << iv.format << " # " << ToStringFormat(iv.format) << std::endl;
+  os << t1 << "format: " << iv.format << " # " << ToStringFormat(iv.format)
+     << std::endl;
 
   if (verbosity_ >= 1) {
     //   SpvReflectTypeDescription*        type_description;
@@ -1613,22 +1974,28 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   //   struct {
   //     uint32_t                        location;
   //   } word_offset;
-  os << t1 << "word_offset: { location: " << iv.word_offset.location << " }" << std::endl;
+  os << t1 << "word_offset: { location: " << iv.word_offset.location << " }"
+     << std::endl;
 
   // } SpvReflectInterfaceVariable;
 }
 
-void SpvReflectToYaml::WriteBlockVariableTypes(std::ostream& os, const SpvReflectBlockVariable& bv, uint32_t indent_level) {
+void SpvReflectToYaml::WriteBlockVariableTypes(
+    std::ostream& os, const SpvReflectBlockVariable& bv,
+    uint32_t indent_level) {
   const auto* td = bv.type_description;
-  if (td && type_description_to_index_.find(td) == type_description_to_index_.end()) {
+  if (td &&
+      type_description_to_index_.find(td) == type_description_to_index_.end()) {
     WriteTypeDescription(os, *td, indent_level);
   }
 
-  for(uint32_t i=0; i<bv.member_count; ++i) {
+  for (uint32_t i = 0; i < bv.member_count; ++i) {
     WriteBlockVariableTypes(os, bv.members[i], indent_level);
   }
 }
-void SpvReflectToYaml::WriteDescriptorBindingTypes(std::ostream& os, const SpvReflectDescriptorBinding& db, uint32_t indent_level) {
+void SpvReflectToYaml::WriteDescriptorBindingTypes(
+    std::ostream& os, const SpvReflectDescriptorBinding& db,
+    uint32_t indent_level) {
   WriteBlockVariableTypes(os, db.block, indent_level);
 
   if (db.uav_counter_binding) {
@@ -1636,33 +2003,35 @@ void SpvReflectToYaml::WriteDescriptorBindingTypes(std::ostream& os, const SpvRe
   }
 
   const auto* td = db.type_description;
-  if (td && type_description_to_index_.find(td) == type_description_to_index_.end()) {
+  if (td &&
+      type_description_to_index_.find(td) == type_description_to_index_.end()) {
     WriteTypeDescription(os, *td, indent_level);
   }
 }
-void SpvReflectToYaml::WriteInterfaceVariableTypes(std::ostream& os, const SpvReflectInterfaceVariable& iv, uint32_t indent_level) {
+void SpvReflectToYaml::WriteInterfaceVariableTypes(
+    std::ostream& os, const SpvReflectInterfaceVariable& iv,
+    uint32_t indent_level) {
   const auto* td = iv.type_description;
-  if (td && type_description_to_index_.find(td) == type_description_to_index_.end()) {
+  if (td &&
+      type_description_to_index_.find(td) == type_description_to_index_.end()) {
     WriteTypeDescription(os, *td, indent_level);
   }
 
-  for(uint32_t i=0; i<iv.member_count; ++i) {
+  for (uint32_t i = 0; i < iv.member_count; ++i) {
     WriteInterfaceVariableTypes(os, iv.members[i], indent_level);
   }
 }
 
-
-void SpvReflectToYaml::Write(std::ostream& os)
-{
+void SpvReflectToYaml::Write(std::ostream& os) {
   if (!sm_._internal) {
     return;
   }
 
   uint32_t indent_level = 0;
   const std::string t0 = Indent(indent_level);
-  const std::string t1 = Indent(indent_level+1);
-  const std::string t2 = Indent(indent_level+2);
-  const std::string t3 = Indent(indent_level+3);
+  const std::string t1 = Indent(indent_level + 1);
+  const std::string t2 = Indent(indent_level + 2);
+  const std::string t3 = Indent(indent_level + 3);
 
   os << "%YAML 1.0" << std::endl;
   os << "---" << std::endl;
@@ -1670,126 +2039,143 @@ void SpvReflectToYaml::Write(std::ostream& os)
   type_description_to_index_.clear();
   if (verbosity_ >= 2) {
     os << t0 << "all_type_descriptions:" << std::endl;
-    // Write the entire internal type_description table; all type descriptions are
-    // reachable from there, though most of them are purely internal & not referenced
-    // by any of the public-facing structures.
-    for(size_t i=0; i<sm_._internal->type_description_count; ++i) {
-      WriteTypeDescription(os, sm_._internal->type_descriptions[i], indent_level+1);
+    // Write the entire internal type_description table; all type descriptions
+    // are reachable from there, though most of them are purely internal & not
+    // referenced by any of the public-facing structures.
+    for (size_t i = 0; i < sm_._internal->type_description_count; ++i) {
+      WriteTypeDescription(os, sm_._internal->type_descriptions[i],
+                           indent_level + 1);
     }
   } else if (verbosity_ >= 1) {
     os << t0 << "all_type_descriptions:" << std::endl;
-    // Iterate through all public-facing structures and write any type descriptions
-    // we find (and their children).
-    for(uint32_t i=0; i<sm_.descriptor_binding_count; ++i) {
-      WriteDescriptorBindingTypes(os, sm_.descriptor_bindings[i], indent_level+1);
+    // Iterate through all public-facing structures and write any type
+    // descriptions we find (and their children).
+    for (uint32_t i = 0; i < sm_.descriptor_binding_count; ++i) {
+      WriteDescriptorBindingTypes(os, sm_.descriptor_bindings[i],
+                                  indent_level + 1);
     }
-    for(uint32_t i=0; i<sm_.push_constant_block_count; ++i) {
-      WriteBlockVariableTypes(os, sm_.push_constant_blocks[i], indent_level+1);
+    for (uint32_t i = 0; i < sm_.push_constant_block_count; ++i) {
+      WriteBlockVariableTypes(os, sm_.push_constant_blocks[i],
+                              indent_level + 1);
     }
-    for(uint32_t i=0; i<sm_.input_variable_count; ++i) {
-      WriteInterfaceVariableTypes(os, *sm_.input_variables[i], indent_level+1);
+    for (uint32_t i = 0; i < sm_.input_variable_count; ++i) {
+      WriteInterfaceVariableTypes(os, *sm_.input_variables[i],
+                                  indent_level + 1);
     }
-    for(uint32_t i=0; i<sm_.output_variable_count; ++i) {
-      WriteInterfaceVariableTypes(os, *sm_.output_variables[i], indent_level+1);
+    for (uint32_t i = 0; i < sm_.output_variable_count; ++i) {
+      WriteInterfaceVariableTypes(os, *sm_.output_variables[i],
+                                  indent_level + 1);
     }
   }
 
   block_variable_to_index_.clear();
   os << t0 << "all_block_variables:" << std::endl;
-  for(uint32_t i=0; i<sm_.descriptor_binding_count; ++i) {
-    WriteBlockVariable(os, sm_.descriptor_bindings[i].block, indent_level+1);
+  for (uint32_t i = 0; i < sm_.descriptor_binding_count; ++i) {
+    WriteBlockVariable(os, sm_.descriptor_bindings[i].block, indent_level + 1);
   }
-  for(uint32_t i=0; i<sm_.push_constant_block_count; ++i) {
-    WriteBlockVariable(os, sm_.push_constant_blocks[i], indent_level+1);
+  for (uint32_t i = 0; i < sm_.push_constant_block_count; ++i) {
+    WriteBlockVariable(os, sm_.push_constant_blocks[i], indent_level + 1);
   }
 
   descriptor_binding_to_index_.clear();
   os << t0 << "all_descriptor_bindings:" << std::endl;
-  for(uint32_t i=0; i<sm_.descriptor_binding_count; ++i) {
-    WriteDescriptorBinding(os, sm_.descriptor_bindings[i], indent_level+1);
+  for (uint32_t i = 0; i < sm_.descriptor_binding_count; ++i) {
+    WriteDescriptorBinding(os, sm_.descriptor_bindings[i], indent_level + 1);
   }
 
   interface_variable_to_index_.clear();
   os << t0 << "all_interface_variables:" << std::endl;
-  for(uint32_t i=0; i<sm_.input_variable_count; ++i) {
-    WriteInterfaceVariable(os, *sm_.input_variables[i], indent_level+1);
+  for (uint32_t i = 0; i < sm_.input_variable_count; ++i) {
+    WriteInterfaceVariable(os, *sm_.input_variables[i], indent_level + 1);
   }
-  for(uint32_t i=0; i<sm_.output_variable_count; ++i) {
-    WriteInterfaceVariable(os, *sm_.output_variables[i], indent_level+1);
+  for (uint32_t i = 0; i < sm_.output_variable_count; ++i) {
+    WriteInterfaceVariable(os, *sm_.output_variables[i], indent_level + 1);
   }
 
   // struct SpvReflectShaderModule {
   os << t0 << "module:" << std::endl;
   // uint16_t                          generator;
-  os << t1 << "generator: " << sm_.generator << " # " << ToStringGenerator(sm_.generator) << std::endl;
+  os << t1 << "generator: " << sm_.generator << " # "
+     << ToStringGenerator(sm_.generator) << std::endl;
   // const char*                       entry_point_name;
-  os << t1 << "entry_point_name: " << SafeString(sm_.entry_point_name) << std::endl;
+  os << t1 << "entry_point_name: " << SafeString(sm_.entry_point_name)
+     << std::endl;
   // uint32_t                          entry_point_id;
   os << t1 << "entry_point_id: " << sm_.entry_point_id << std::endl;
   // SpvSourceLanguage                 source_language;
-  os << t1 << "source_language: " << sm_.source_language << " # " << ToStringSpvSourceLanguage(sm_.source_language) << std::endl;
+  os << t1 << "source_language: " << sm_.source_language << " # "
+     << ToStringSpvSourceLanguage(sm_.source_language) << std::endl;
   // uint32_t                          source_language_version;
-  os << t1 << "source_language_version: " << sm_.source_language_version << std::endl;
+  os << t1 << "source_language_version: " << sm_.source_language_version
+     << std::endl;
   // SpvExecutionModel                 spirv_execution_model;
-  os << t1 << "spirv_execution_model: " << sm_.spirv_execution_model << " # " << ToStringSpvExecutionModel(sm_.spirv_execution_model) << std::endl;
+  os << t1 << "spirv_execution_model: " << sm_.spirv_execution_model << " # "
+     << ToStringSpvExecutionModel(sm_.spirv_execution_model) << std::endl;
   // SpvShaderStageFlagBits             shader_stage;
-  os << t1 << "shader_stage: " << AsHexString(sm_.shader_stage) << " # " << ToStringShaderStage(sm_.shader_stage) << std::endl;
+  os << t1 << "shader_stage: " << AsHexString(sm_.shader_stage) << " # "
+     << ToStringShaderStage(sm_.shader_stage) << std::endl;
   // uint32_t                          descriptor_binding_count;
-  os << t1 << "descriptor_binding_count: " << sm_.descriptor_binding_count << std::endl;
+  os << t1 << "descriptor_binding_count: " << sm_.descriptor_binding_count
+     << std::endl;
   // SpvReflectDescriptorBinding*      descriptor_bindings;
   os << t1 << "descriptor_bindings:" << std::endl;
-  for(uint32_t i=0; i<sm_.descriptor_binding_count; ++i) {
+  for (uint32_t i = 0; i < sm_.descriptor_binding_count; ++i) {
     auto itor = descriptor_binding_to_index_.find(&sm_.descriptor_bindings[i]);
     assert(itor != descriptor_binding_to_index_.end());
-    os << t2 << "- *db" << itor->second << " # " << SafeString(sm_.descriptor_bindings[i].name) << std::endl;
+    os << t2 << "- *db" << itor->second << " # "
+       << SafeString(sm_.descriptor_bindings[i].name) << std::endl;
   }
   // uint32_t                          descriptor_set_count;
   os << t1 << "descriptor_set_count: " << sm_.descriptor_set_count << std::endl;
   // SpvReflectDescriptorSet descriptor_sets[SPV_REFLECT_MAX_DESCRIPTOR_SETS];
   os << t1 << "descriptor_sets:" << std::endl;
-  for(uint32_t i_set=0; i_set<sm_.descriptor_set_count; ++i_set) {
+  for (uint32_t i_set = 0; i_set < sm_.descriptor_set_count; ++i_set) {
     // typedef struct SpvReflectDescriptorSet {
     const auto& dset = sm_.descriptor_sets[i_set];
     //   uint32_t                          set;
-    os << t1 << "- " << "set: " << dset.set << std::endl;
+    os << t1 << "- "
+       << "set: " << dset.set << std::endl;
     //   uint32_t                          binding_count;
     os << t2 << "binding_count: " << dset.binding_count << std::endl;
     //   SpvReflectDescriptorBinding**     bindings;
     os << t2 << "bindings:" << std::endl;
-    for(uint32_t i_binding=0; i_binding < dset.binding_count; ++i_binding) {
+    for (uint32_t i_binding = 0; i_binding < dset.binding_count; ++i_binding) {
       auto itor = descriptor_binding_to_index_.find(dset.bindings[i_binding]);
       assert(itor != descriptor_binding_to_index_.end());
-      os << t3 << "- *db" << itor->second << " # " << SafeString(dset.bindings[i_binding]->name) << std::endl;
+      os << t3 << "- *db" << itor->second << " # "
+         << SafeString(dset.bindings[i_binding]->name) << std::endl;
     }
     // } SpvReflectDescriptorSet;
-
   }
   // uint32_t                          input_variable_count;
   os << t1 << "input_variable_count: " << sm_.input_variable_count << ",\n";
   // SpvReflectInterfaceVariable*      input_variables;
   os << t1 << "input_variables:" << std::endl;
-  for(uint32_t i=0; i < sm_.input_variable_count; ++i) {
+  for (uint32_t i = 0; i < sm_.input_variable_count; ++i) {
     auto itor = interface_variable_to_index_.find(sm_.input_variables[i]);
     assert(itor != interface_variable_to_index_.end());
-    os << t2 << "- *iv" << itor->second << " # " << SafeString(sm_.input_variables[i]->name) << std::endl;
+    os << t2 << "- *iv" << itor->second << " # "
+       << SafeString(sm_.input_variables[i]->name) << std::endl;
   }
   // uint32_t                          output_variable_count;
   os << t1 << "output_variable_count: " << sm_.output_variable_count << ",\n";
   // SpvReflectInterfaceVariable*      output_variables;
   os << t1 << "output_variables:" << std::endl;
-  for(uint32_t i=0; i < sm_.output_variable_count; ++i) {
+  for (uint32_t i = 0; i < sm_.output_variable_count; ++i) {
     auto itor = interface_variable_to_index_.find(sm_.output_variables[i]);
     assert(itor != interface_variable_to_index_.end());
-    os << t2 << "- *iv" << itor->second << " # " << SafeString(sm_.output_variables[i]->name) << std::endl;
+    os << t2 << "- *iv" << itor->second << " # "
+       << SafeString(sm_.output_variables[i]->name) << std::endl;
   }
   // uint32_t                          push_constant_count;
   os << t1 << "push_constant_count: " << sm_.push_constant_block_count << ",\n";
   // SpvReflectBlockVariable*          push_constants;
   os << t1 << "push_constants:" << std::endl;
-  for(uint32_t i=0; i<sm_.push_constant_block_count; ++i) {
+  for (uint32_t i = 0; i < sm_.push_constant_block_count; ++i) {
     auto itor = block_variable_to_index_.find(&sm_.push_constant_blocks[i]);
     assert(itor != block_variable_to_index_.end());
-    os << t2 << "- *bv" << itor->second << " # " << SafeString(sm_.push_constant_blocks[i].name) << std::endl;
+    os << t2 << "- *bv" << itor->second << " # "
+       << SafeString(sm_.push_constant_blocks[i].name) << std::endl;
   }
 
   if (verbosity_ >= 2) {
@@ -1800,7 +2186,7 @@ void SpvReflectToYaml::Write(std::ostream& os)
       os << t2 << "spirv_size: " << sm_._internal->spirv_size << std::endl;
       //   uint32_t*                       spirv_code;
       os << t2 << "spirv_code: [";
-      for(size_t i=0; i < sm_._internal->spirv_word_count; ++i) {
+      for (size_t i = 0; i < sm_._internal->spirv_word_count; ++i) {
         if ((i % 6) == 0) {
           os << std::endl << t3;
         }
@@ -1808,13 +2194,17 @@ void SpvReflectToYaml::Write(std::ostream& os)
       }
       os << "]" << std::endl;
       //   uint32_t                        spirv_word_count;
-      os << t2 << "spirv_word_count: " << sm_._internal->spirv_word_count << std::endl;
+      os << t2 << "spirv_word_count: " << sm_._internal->spirv_word_count
+         << std::endl;
       //   size_t                          type_description_count;
-      os << t2 << "type_description_count: " << sm_._internal->type_description_count << std::endl;
+      os << t2
+         << "type_description_count: " << sm_._internal->type_description_count
+         << std::endl;
       //   SpvReflectTypeDescription*      type_descriptions;
       os << t2 << "type_descriptions:" << std::endl;
-      for(uint32_t i=0; i<sm_._internal->type_description_count; ++i) {
-        auto itor = type_description_to_index_.find(&sm_._internal->type_descriptions[i]);
+      for (uint32_t i = 0; i < sm_._internal->type_description_count; ++i) {
+        auto itor = type_description_to_index_.find(
+            &sm_._internal->type_descriptions[i]);
         assert(itor != type_description_to_index_.end());
         os << t3 << "- *td" << itor->second << std::endl;
       }

--- a/examples/arg_parser.cpp
+++ b/examples/arg_parser.cpp
@@ -1,70 +1,67 @@
 #include "arg_parser.h"
+
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
 
-ArgParser::ArgParser()
-{
-}
+ArgParser::ArgParser() {}
 
-ArgParser::~ArgParser()
-{
-}
+ArgParser::~ArgParser() {}
 
-ArgParser::Option* ArgParser::FindOptionByShortName(const std::string& short_name)
-{
+ArgParser::Option* ArgParser::FindOptionByShortName(
+    const std::string& short_name) {
   ArgParser::Option* p_option = nullptr;
-  auto it = std::find_if(std::begin(m_options),
-                         std::end(m_options),
+  auto it = std::find_if(std::begin(m_options), std::end(m_options),
                          [short_name](const ArgParser::Option& elem) -> bool {
-                             return elem.short_name == short_name; });
+                           return elem.short_name == short_name;
+                         });
   if (it != std::end(m_options)) {
     p_option = &(*it);
   }
   return p_option;
 }
 
-const ArgParser::Option* ArgParser::FindOptionByShortName(const std::string& short_name) const
-{
+const ArgParser::Option* ArgParser::FindOptionByShortName(
+    const std::string& short_name) const {
   const ArgParser::Option* p_option = nullptr;
-  auto it = std::find_if(std::begin(m_options),
-                         std::end(m_options),
+  auto it = std::find_if(std::begin(m_options), std::end(m_options),
                          [short_name](const ArgParser::Option& elem) -> bool {
-                             return elem.short_name == short_name; });
+                           return elem.short_name == short_name;
+                         });
   if (it != std::end(m_options)) {
     p_option = &(*it);
   }
   return p_option;
 }
 
-ArgParser::Option* ArgParser::FindOptionByLongName(const std::string& long_name)
-{
+ArgParser::Option* ArgParser::FindOptionByLongName(
+    const std::string& long_name) {
   ArgParser::Option* p_option = nullptr;
-  auto it = std::find_if(std::begin(m_options),
-                         std::end(m_options),
+  auto it = std::find_if(std::begin(m_options), std::end(m_options),
                          [long_name](const ArgParser::Option& elem) -> bool {
-                             return elem.long_name == long_name; });
+                           return elem.long_name == long_name;
+                         });
   if (it != std::end(m_options)) {
     p_option = &(*it);
   }
   return p_option;
 }
 
-const ArgParser::Option* ArgParser::FindOptionByLongName(const std::string& long_name) const
-{
+const ArgParser::Option* ArgParser::FindOptionByLongName(
+    const std::string& long_name) const {
   const ArgParser::Option* p_option = nullptr;
-  auto it = std::find_if(std::begin(m_options),
-                         std::end(m_options),
+  auto it = std::find_if(std::begin(m_options), std::end(m_options),
                          [long_name](const ArgParser::Option& elem) -> bool {
-                             return elem.long_name == long_name; });
+                           return elem.long_name == long_name;
+                         });
   if (it != std::end(m_options)) {
     p_option = &(*it);
   }
   return p_option;
 }
 
-bool ArgParser::AddFlag(const std::string& short_name, const std::string& long_name, const std::string& desc)
-{
+bool ArgParser::AddFlag(const std::string& short_name,
+                        const std::string& long_name, const std::string& desc) {
   Option option = {};
   option.short_name = short_name;
   option.long_name = long_name;
@@ -79,8 +76,10 @@ bool ArgParser::AddFlag(const std::string& short_name, const std::string& long_n
   return true;
 }
 
-bool ArgParser::AddOptionString(const std::string& short_name, const std::string& long_name, const std::string& desc, const std::string& default_value)
-{
+bool ArgParser::AddOptionString(const std::string& short_name,
+                                const std::string& long_name,
+                                const std::string& desc,
+                                const std::string& default_value) {
   Option option = {};
   option.short_name = short_name;
   option.long_name = long_name;
@@ -96,8 +95,9 @@ bool ArgParser::AddOptionString(const std::string& short_name, const std::string
   return true;
 }
 
-bool ArgParser::AddOptionInt(const std::string& short_name, const std::string& long_name, const std::string& desc, int default_value)
-{
+bool ArgParser::AddOptionInt(const std::string& short_name,
+                             const std::string& long_name,
+                             const std::string& desc, int default_value) {
   Option option = {};
   option.short_name = short_name;
   option.long_name = long_name;
@@ -113,8 +113,9 @@ bool ArgParser::AddOptionInt(const std::string& short_name, const std::string& l
   return true;
 }
 
-bool ArgParser::AddOptionFloat(const std::string& short_name, const std::string& long_name, const std::string& desc, float default_value)
-{
+bool ArgParser::AddOptionFloat(const std::string& short_name,
+                               const std::string& long_name,
+                               const std::string& desc, float default_value) {
   Option option = {};
   option.short_name = short_name;
   option.long_name = long_name;
@@ -130,8 +131,7 @@ bool ArgParser::AddOptionFloat(const std::string& short_name, const std::string&
   return true;
 }
 
-bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
-{
+bool ArgParser::Parse(int argc, char** argv, std::ostream& os) {
   for (auto& opt : m_options) {
     opt.value = opt.default_value;
     opt.parsed = false;
@@ -145,8 +145,7 @@ bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
       if ((s.length() >= 2) && ((s[0] == '-') && (s[1] == '-'))) {
         std::string long_name = s.substr(2);
         p_option = FindOptionByLongName(long_name);
-      }
-      else {
+      } else {
         std::string short_name = s.substr(1);
         p_option = FindOptionByShortName(short_name);
       }
@@ -160,8 +159,7 @@ bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
         case OPTION_TYPE_FLAG: {
           p_option->parsed = true;
           i += 1;
-        }
-        break;
+        } break;
 
         case OPTION_TYPE_STRING: {
           if ((i + 1) >= argc) {
@@ -174,8 +172,7 @@ bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
           p_option->parsed = true;
 
           i += 2;
-        }
-        break;
+        } break;
 
         case OPTION_TYPE_INT: {
           if ((i + 1) >= argc) {
@@ -188,8 +185,7 @@ bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
           p_option->parsed = true;
 
           i += 2;
-        }
-        break;
+        } break;
 
         case OPTION_TYPE_FLOAT: {
           if ((i + 1) >= argc) {
@@ -202,30 +198,23 @@ bool ArgParser::Parse(int argc, char** argv, std::ostream& os)
           p_option->parsed = true;
 
           i += 2;
-        }
-        break;
+        } break;
 
         case OPTION_TYPE_UNDEFINED: {
-        }
-        break;
+        } break;
       }
-    }
-    else {
+    } else {
       m_args.push_back(s);
       i += 1;
-    }    
+    }
   }
 
   return true;
 }
 
-size_t ArgParser::GetArgCount() const
-{
-  return m_args.size();
-}
+size_t ArgParser::GetArgCount() const { return m_args.size(); }
 
-bool ArgParser::GetArg(size_t i, std::string* p_value) const
-{
+bool ArgParser::GetArg(size_t i, std::string* p_value) const {
   if ((GetArgCount() == 0) && (i >= GetArgCount())) {
     return false;
   }
@@ -237,13 +226,10 @@ bool ArgParser::GetArg(size_t i, std::string* p_value) const
   return true;
 }
 
-const std::vector<std::string>& ArgParser::GetArgs() const
-{
-  return m_args;
-}
+const std::vector<std::string>& ArgParser::GetArgs() const { return m_args; }
 
-bool ArgParser::GetFlag(const std::string& short_name, const std::string& long_name) const
-{
+bool ArgParser::GetFlag(const std::string& short_name,
+                        const std::string& long_name) const {
   auto p_short = FindOptionByShortName(short_name);
   auto p_long = FindOptionByLongName(long_name);
 
@@ -266,8 +252,9 @@ bool ArgParser::GetFlag(const std::string& short_name, const std::string& long_n
   return p_option->parsed;
 }
 
-bool ArgParser::GetString(const std::string& short_name, const std::string& long_name, std::string* p_value) const
-{
+bool ArgParser::GetString(const std::string& short_name,
+                          const std::string& long_name,
+                          std::string* p_value) const {
   auto p_short = FindOptionByShortName(short_name);
   auto p_long = FindOptionByLongName(long_name);
 
@@ -282,11 +269,11 @@ bool ArgParser::GetString(const std::string& short_name, const std::string& long
   if (p_option == nullptr) {
     return false;
   }
-  
+
   if (!p_option->parsed || (p_option->type != OPTION_TYPE_STRING)) {
     return false;
   }
-    
+
   if (p_value != nullptr) {
     *p_value = p_option->value.str;
   }
@@ -294,8 +281,8 @@ bool ArgParser::GetString(const std::string& short_name, const std::string& long
   return true;
 }
 
-bool ArgParser::GetInt(const std::string& short_name, const std::string& long_name, int* p_value) const
-{
+bool ArgParser::GetInt(const std::string& short_name,
+                       const std::string& long_name, int* p_value) const {
   auto p_short = FindOptionByShortName(short_name);
   auto p_long = FindOptionByLongName(long_name);
 
@@ -310,11 +297,11 @@ bool ArgParser::GetInt(const std::string& short_name, const std::string& long_na
   if (p_option == nullptr) {
     return false;
   }
-  
+
   if (!p_option->parsed || (p_option->type != OPTION_TYPE_INT)) {
     return false;
   }
-  
+
   if (p_value != nullptr) {
     *p_value = p_option->value.i32;
   }
@@ -322,8 +309,8 @@ bool ArgParser::GetInt(const std::string& short_name, const std::string& long_na
   return true;
 }
 
-bool ArgParser::GetFloat(const std::string& short_name, const std::string& long_name, float* p_value) const
-{
+bool ArgParser::GetFloat(const std::string& short_name,
+                         const std::string& long_name, float* p_value) const {
   auto p_short = FindOptionByShortName(short_name);
   auto p_long = FindOptionByLongName(long_name);
 
@@ -338,11 +325,11 @@ bool ArgParser::GetFloat(const std::string& short_name, const std::string& long_
   if (p_option == nullptr) {
     return false;
   }
-  
+
   if (!p_option->parsed || (p_option->type != OPTION_TYPE_FLOAT)) {
     return false;
   }
-  
+
   if (p_value != nullptr) {
     *p_value = p_option->value.f32;
   }
@@ -350,49 +337,48 @@ bool ArgParser::GetFloat(const std::string& short_name, const std::string& long_
   return true;
 }
 
-void ArgParser::PrintHelp(std::ostream& os)
-{
-	(void)os;
+void ArgParser::PrintHelp(std::ostream& os) {
+  (void)os;
 
-/*
-  if (m_options.empty()) {
-    return;
-  }
-
-  struct TextLine {
-    std::string   option;
-    std::string   desc;
-  };
-  std::vector<TextLine> text_lines;
-
-  size_t max_width = 0;
-  for (auto& it : m_options) {
-    std::stringstream ss;
-    ss << "--" << it.first;
-    switch (it.second.type) {
-      default: break;
-      case OPTION_TYPE_STRING : ss << " " << "[s]"; break;
-      case OPTION_TYPE_INT    : ss << " " << "[i]"; break;
-      case OPTION_TYPE_FLOAT  : ss << " " << "[f]"; break;
+  /*
+    if (m_options.empty()) {
+      return;
     }
 
-    std::string option = ss.str();
-    max_width = std::max(max_width, option.size());
+    struct TextLine {
+      std::string   option;
+      std::string   desc;
+    };
+    std::vector<TextLine> text_lines;
 
-    TextLine tl;
-    tl.option = option;
-    tl.desc = it.second.desc;
-    text_lines.push_back(tl);
-  }
-  max_width += 2;
+    size_t max_width = 0;
+    for (auto& it : m_options) {
+      std::stringstream ss;
+      ss << "--" << it.first;
+      switch (it.second.type) {
+        default: break;
+        case OPTION_TYPE_STRING : ss << " " << "[s]"; break;
+        case OPTION_TYPE_INT    : ss << " " << "[i]"; break;
+        case OPTION_TYPE_FLOAT  : ss << " " << "[f]"; break;
+      }
 
-  os << "\n";
-  os << "Options:" << "\n";
-  for (auto& tl : text_lines) {
-    os << "  ";
-    os << std::left << std::setw(max_width) << tl.option;
-    os << tl.desc;
+      std::string option = ss.str();
+      max_width = std::max(max_width, option.size());
+
+      TextLine tl;
+      tl.option = option;
+      tl.desc = it.second.desc;
+      text_lines.push_back(tl);
+    }
+    max_width += 2;
+
     os << "\n";
-  }
-*/
+    os << "Options:" << "\n";
+    for (auto& tl : text_lines) {
+      os << "  ";
+      os << std::left << std::setw(max_width) << tl.option;
+      os << tl.desc;
+      os << "\n";
+    }
+  */
 }

--- a/examples/common.cpp
+++ b/examples/common.cpp
@@ -1,34 +1,48 @@
 #include "common.h"
 
-#include "../common/output_stream.h"
-
 #include <cstring>
 #include <fstream>
 #include <sstream>
 
-void PrintModuleInfo(std::ostream& os, const SpvReflectShaderModule& obj, const char* /*indent*/)
-{
+#include "../common/output_stream.h"
+
+void PrintModuleInfo(std::ostream& os, const SpvReflectShaderModule& obj,
+                     const char* /*indent*/) {
   os << "entry point     : " << obj.entry_point_name << "\n";
-  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language) << "\n";
+  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language)
+     << "\n";
   os << "source lang ver : " << obj.source_language_version << "\n";
   if (obj.source_language == SpvSourceLanguageHLSL) {
     os << "stage           : ";
     switch (obj.shader_stage) {
-      default: break;
-      case SPV_REFLECT_SHADER_STAGE_VERTEX_BIT                   : os << "VS"; break;
-      case SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT     : os << "HS"; break;
-      case SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT  : os << "DS"; break;
-      case SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT                 : os << "GS"; break;
-      case SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT                 : os << "PS"; break;
-      case SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT                  : os << "CS"; break;
+      default:
+        break;
+      case SPV_REFLECT_SHADER_STAGE_VERTEX_BIT:
+        os << "VS";
+        break;
+      case SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+        os << "HS";
+        break;
+      case SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+        os << "DS";
+        break;
+      case SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT:
+        os << "GS";
+        break;
+      case SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT:
+        os << "PS";
+        break;
+      case SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT:
+        os << "CS";
+        break;
     }
   }
 }
 
-void PrintDescriptorSet(std::ostream& os, const SpvReflectDescriptorSet& obj, const char* indent)
-{
-  const char* t     = indent;
-  std::string tt    = std::string(indent) + "  ";
+void PrintDescriptorSet(std::ostream& os, const SpvReflectDescriptorSet& obj,
+                        const char* indent) {
+  const char* t = indent;
+  std::string tt = std::string(indent) + "  ";
   std::string ttttt = std::string(indent) + "    ";
 
   os << t << "set           : " << obj.set << "\n";
@@ -36,7 +50,8 @@ void PrintDescriptorSet(std::ostream& os, const SpvReflectDescriptorSet& obj, co
   os << "\n";
   for (uint32_t i = 0; i < obj.binding_count; ++i) {
     const SpvReflectDescriptorBinding& binding = *obj.bindings[i];
-    os << tt << i << ":" << "\n";
+    os << tt << i << ":"
+       << "\n";
     PrintDescriptorBinding(os, binding, false, ttttt.c_str());
     if (i < (obj.binding_count - 1)) {
       os << "\n";
@@ -44,19 +59,22 @@ void PrintDescriptorSet(std::ostream& os, const SpvReflectDescriptorSet& obj, co
   }
 }
 
-void PrintDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBinding& obj, bool write_set, const char* indent)
-{
+void PrintDescriptorBinding(std::ostream& os,
+                            const SpvReflectDescriptorBinding& obj,
+                            bool write_set, const char* indent) {
   const char* t = indent;
   os << t << "binding : " << obj.binding << "\n";
   if (write_set) {
     os << t << "set     : " << obj.set << "\n";
   }
-  os << t << "type    : " << ToStringDescriptorType(obj.descriptor_type) << "\n";
+  os << t << "type    : " << ToStringDescriptorType(obj.descriptor_type)
+     << "\n";
 
   // array
   if (obj.array.dims_count > 0) {
     os << t << "array   : ";
-    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count; ++dim_index) {
+    for (uint32_t dim_index = 0; dim_index < obj.array.dims_count;
+         ++dim_index) {
       os << "[" << obj.array.dims[dim_index] << "]";
     }
     os << "\n";
@@ -74,38 +92,43 @@ void PrintDescriptorBinding(std::ostream& os, const SpvReflectDescriptorBinding&
   }
 
   os << t << "name    : " << obj.name;
-  if ((obj.type_description->type_name != nullptr) && (strlen(obj.type_description->type_name) > 0)) {
-    os << " " << "(" << obj.type_description->type_name << ")";
+  if ((obj.type_description->type_name != nullptr) &&
+      (strlen(obj.type_description->type_name) > 0)) {
+    os << " "
+       << "(" << obj.type_description->type_name << ")";
   }
 }
 
-void PrintInterfaceVariable(std::ostream& os, SpvSourceLanguage src_lang, const SpvReflectInterfaceVariable& obj, const char* indent)
-{
+void PrintInterfaceVariable(std::ostream& os, SpvSourceLanguage src_lang,
+                            const SpvReflectInterfaceVariable& obj,
+                            const char* indent) {
   const char* t = indent;
   os << t << "location  : ";
   if (obj.decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) {
-    os << ToStringSpvBuiltIn(obj.built_in) << " " << "(built-in)";
-  }
-  else {
+    os << ToStringSpvBuiltIn(obj.built_in) << " "
+       << "(built-in)";
+  } else {
     os << obj.location;
   }
   os << "\n";
   if (obj.semantic != nullptr) {
     os << t << "semantic  : " << obj.semantic << "\n";
   }
-  os << t << "type      : " << ToStringType(src_lang, *obj.type_description) << "\n";
+  os << t << "type      : " << ToStringType(src_lang, *obj.type_description)
+     << "\n";
   os << t << "format    : " << ToStringFormat(obj.format) << "\n";
   os << t << "qualifier : ";
   if (obj.decoration_flags & SPV_REFLECT_DECORATION_FLAT) {
     os << "flat";
-  }
-  else   if (obj.decoration_flags & SPV_REFLECT_DECORATION_NOPERSPECTIVE) {
+  } else if (obj.decoration_flags & SPV_REFLECT_DECORATION_NOPERSPECTIVE) {
     os << "noperspective";
   }
   os << "\n";
 
   os << t << "name      : " << obj.name;
-  if ((obj.type_description->type_name != nullptr) && (strlen(obj.type_description->type_name) > 0)) {
-    os << " " << "(" << obj.type_description->type_name << ")";
+  if ((obj.type_description->type_name != nullptr) &&
+      (strlen(obj.type_description->type_name) > 0)) {
+    os << " "
+       << "(" << obj.type_description->type_name << ")";
   }
 }

--- a/examples/main_descriptors.cpp
+++ b/examples/main_descriptors.cpp
@@ -1,6 +1,7 @@
+#include <cassert>
+
 #include "common.h"
 #include "sample_spv.h"
-#include <cassert>
 
 #if defined(SPIRV_REFLECT_HAS_VULKAN_H)
 #include <vulkan/vulkan.h>
@@ -11,10 +12,10 @@ struct DescriptorSetLayoutData {
 };
 #endif
 
-int main(int argn, char** argv)
-{
+int main(int argn, char** argv) {
   SpvReflectShaderModule module = {};
-  SpvReflectResult result = spvReflectCreateShaderModule(sizeof(k_sample_spv), k_sample_spv, &module);
+  SpvReflectResult result =
+      spvReflectCreateShaderModule(sizeof(k_sample_spv), k_sample_spv, &module);
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
   uint32_t count = 0;
@@ -28,50 +29,59 @@ int main(int argn, char** argv)
 #if defined(SPIRV_REFLECT_HAS_VULKAN_H)
   // Demonstrates how to generate all necessary data structures to create a
   // VkDescriptorSetLayout for each descriptor set in this shader.
-  std::vector<DescriptorSetLayoutData> set_layouts(sets.size(), DescriptorSetLayoutData{});
+  std::vector<DescriptorSetLayoutData> set_layouts(sets.size(),
+                                                   DescriptorSetLayoutData{});
   for (size_t i_set = 0; i_set < sets.size(); ++i_set) {
     const SpvReflectDescriptorSet& refl_set = *(sets[i_set]);
     DescriptorSetLayoutData& layout = set_layouts[i_set];
     layout.bindings.resize(refl_set.binding_count);
-    for (uint32_t i_binding = 0; i_binding < refl_set.binding_count; ++i_binding) {
-      const SpvReflectDescriptorBinding& refl_binding = *(refl_set.bindings[i_binding]);
+    for (uint32_t i_binding = 0; i_binding < refl_set.binding_count;
+         ++i_binding) {
+      const SpvReflectDescriptorBinding& refl_binding =
+          *(refl_set.bindings[i_binding]);
       VkDescriptorSetLayoutBinding& layout_binding = layout.bindings[i_binding];
       layout_binding.binding = refl_binding.binding;
-      layout_binding.descriptorType = static_cast<VkDescriptorType>(refl_binding.descriptor_type);
+      layout_binding.descriptorType =
+          static_cast<VkDescriptorType>(refl_binding.descriptor_type);
       layout_binding.descriptorCount = 1;
       for (uint32_t i_dim = 0; i_dim < refl_binding.array.dims_count; ++i_dim) {
         layout_binding.descriptorCount *= refl_binding.array.dims[i_dim];
       }
-      layout_binding.stageFlags = static_cast<VkShaderStageFlagBits>(module.shader_stage);
+      layout_binding.stageFlags =
+          static_cast<VkShaderStageFlagBits>(module.shader_stage);
     }
     layout.set_number = refl_set.set;
-    layout.create_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layout.create_info.sType =
+        VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
     layout.create_info.bindingCount = refl_set.binding_count;
     layout.create_info.pBindings = layout.bindings.data();
   }
-  // Nothing further is done with set_layouts in this sample; in a real application
-  // they would be merged with similar structures from other shader stages and/or pipelines
-  // to create a VkPipelineLayout.
+  // Nothing further is done with set_layouts in this sample; in a real
+  // application they would be merged with similar structures from other shader
+  // stages and/or pipelines to create a VkPipelineLayout.
 #endif
 
   // Log the descriptor set contents to stdout
-  const char* t  = "  ";
+  const char* t = "  ";
   const char* tt = "    ";
 
   PrintModuleInfo(std::cout, module);
   std::cout << "\n\n";
 
-  std::cout << "Descriptor sets:" << "\n";
+  std::cout << "Descriptor sets:"
+            << "\n";
   for (size_t index = 0; index < sets.size(); ++index) {
     auto p_set = sets[index];
 
-    // descriptor sets can also be retrieved directly from the module, by set index
+    // descriptor sets can also be retrieved directly from the module, by set
+    // index
     auto p_set2 = spvReflectGetDescriptorSet(&module, p_set->set, &result);
     assert(result == SPV_REFLECT_RESULT_SUCCESS);
     assert(p_set == p_set2);
     (void)p_set2;
 
-    std::cout << t << index << ":" << "\n";
+    std::cout << t << index << ":"
+              << "\n";
     PrintDescriptorSet(std::cout, *p_set, tt);
     std::cout << "\n\n";
   }

--- a/examples/main_hlsl_resource_types.cpp
+++ b/examples/main_hlsl_resource_types.cpp
@@ -15,33 +15,38 @@
 */
 
 #if defined(WIN32)
-  #define _CRTDBG_MAP_ALLOC
-  #include <stdlib.h>
-  #include <crtdbg.h>
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#include <stdlib.h>
 #endif
 
 #include <cassert>
 #include <cstring>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <vector>
 
-#include "spirv_reflect.h"
-#include "examples/common.h"
 #include "../common/output_stream.h"
+#include "examples/common.h"
+#include "spirv_reflect.h"
 
-void StreamWrite(std::ostream& os, const SpvReflectDescriptorBinding& obj, bool write_set, const char* indent = "")
-{
+void StreamWrite(std::ostream& os, const SpvReflectDescriptorBinding& obj,
+                 bool write_set, const char* indent = "") {
   const char* t = indent;
 
   os << " " << obj.name;
   os << "\n";
   os << t;
   os << ToStringDescriptorType(obj.descriptor_type);
-  os << " " << "(" << ToStringResourceType(obj.resource_type) << ")";
-  if ((obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE) || (obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
-      (obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) || (obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
+  os << " "
+     << "(" << ToStringResourceType(obj.resource_type) << ")";
+  if ((obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
+      (obj.descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
+      (obj.descriptor_type ==
+       SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) ||
+      (obj.descriptor_type ==
+       SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
     os << "\n";
     os << t;
     os << "dim=" << obj.image.dim << ", ";
@@ -52,24 +57,23 @@ void StreamWrite(std::ostream& os, const SpvReflectDescriptorBinding& obj, bool 
   }
 }
 
-void StreamWrite(std::ostream& os, const SpvReflectShaderModule& obj, const char* indent = "")
-{
+void StreamWrite(std::ostream& os, const SpvReflectShaderModule& obj,
+                 const char* indent = "") {
   os << "entry point     : " << obj.entry_point_name << "\n";
-  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language) << "\n";
+  os << "source lang     : " << spvReflectSourceLanguage(obj.source_language)
+     << "\n";
   os << "source lang ver : " << obj.source_language_version;
 }
 
-void StreamWrite(std::ostream& os, const SpvReflectDescriptorBinding& obj)
-{
+void StreamWrite(std::ostream& os, const SpvReflectDescriptorBinding& obj) {
   StreamWrite(os, obj, true, "  ");
 }
 
 // Specialized stream-writer that only includes descriptor bindings.
-void StreamWrite(std::ostream& os, const spv_reflect::ShaderModule& obj)
-{
-  const char* t     = "  ";
-  const char* tt    = "    ";
-  const char* ttt   = "      ";
+void StreamWrite(std::ostream& os, const spv_reflect::ShaderModule& obj) {
+  const char* t = "  ";
+  const char* tt = "    ";
+  const char* ttt = "      ";
 
   StreamWrite(os, obj.GetShaderModule(), "");
 
@@ -104,19 +108,19 @@ void StreamWrite(std::ostream& os, const spv_reflect::ShaderModule& obj)
 // =================================================================================================
 // PrintUsage()
 // =================================================================================================
-void PrintUsage()
-{
-  std::cout << "Usage: hlsl_resource_types [OPTIONS] path/to/SPIR-V/bytecode.spv" << std::endl
-            << "Options:" << std::endl
-            << " --help:               Display this message" << std::endl
-            << std::endl;
+void PrintUsage() {
+  std::cout
+      << "Usage: hlsl_resource_types [OPTIONS] path/to/SPIR-V/bytecode.spv"
+      << std::endl
+      << "Options:" << std::endl
+      << " --help:               Display this message" << std::endl
+      << std::endl;
 }
 
 // =================================================================================================
 // main()
 // =================================================================================================
-int main(int argn, char** argv)
-{
+int main(int argn, char** argv) {
   if (argn != 2) {
     PrintUsage();
     return EXIT_FAILURE;
@@ -128,7 +132,8 @@ int main(int argn, char** argv)
 
   std::ifstream spv_ifstream(input_spv_path.c_str(), std::ios::binary);
   if (!spv_ifstream.is_open()) {
-    std::cerr << "ERROR: could not open '" << input_spv_path << "' for reading" << std::endl;
+    std::cerr << "ERROR: could not open '" << input_spv_path << "' for reading"
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -150,7 +155,6 @@ int main(int argn, char** argv)
     StreamWrite(std::cout, reflection);
     std::cout << std::endl << std::endl;
   }
-
 
   return 0;
 }

--- a/examples/main_io_variables.cpp
+++ b/examples/main_io_variables.cpp
@@ -1,153 +1,401 @@
-#include "common.h"
-#include "sample_spv.h"
-
 #include <algorithm>
 #include <cassert>
+
+#include "common.h"
+#include "sample_spv.h"
 
 #if defined(SPIRV_REFLECT_HAS_VULKAN_H)
 #include <vulkan/vulkan.h>
 // Returns the size in bytes of the provided VkFormat.
-// As this is only intended for vertex attribute formats, not all VkFormats are supported.
-static uint32_t FormatSize(VkFormat format)
-{
+// As this is only intended for vertex attribute formats, not all VkFormats are
+// supported.
+static uint32_t FormatSize(VkFormat format) {
   uint32_t result = 0;
   switch (format) {
-  case VK_FORMAT_UNDEFINED: result = 0; break;
-  case VK_FORMAT_R4G4_UNORM_PACK8: result = 1; break;
-  case VK_FORMAT_R4G4B4A4_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_B4G4R4A4_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_R5G6B5_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_B5G6R5_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_R5G5B5A1_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_B5G5R5A1_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_A1R5G5B5_UNORM_PACK16: result = 2; break;
-  case VK_FORMAT_R8_UNORM: result = 1; break;
-  case VK_FORMAT_R8_SNORM: result = 1; break;
-  case VK_FORMAT_R8_USCALED: result = 1; break;
-  case VK_FORMAT_R8_SSCALED: result = 1; break;
-  case VK_FORMAT_R8_UINT: result = 1; break;
-  case VK_FORMAT_R8_SINT: result = 1; break;
-  case VK_FORMAT_R8_SRGB: result = 1; break;
-  case VK_FORMAT_R8G8_UNORM: result = 2; break;
-  case VK_FORMAT_R8G8_SNORM: result = 2; break;
-  case VK_FORMAT_R8G8_USCALED: result = 2; break;
-  case VK_FORMAT_R8G8_SSCALED: result = 2; break;
-  case VK_FORMAT_R8G8_UINT: result = 2; break;
-  case VK_FORMAT_R8G8_SINT: result = 2; break;
-  case VK_FORMAT_R8G8_SRGB: result = 2; break;
-  case VK_FORMAT_R8G8B8_UNORM: result = 3; break;
-  case VK_FORMAT_R8G8B8_SNORM: result = 3; break;
-  case VK_FORMAT_R8G8B8_USCALED: result = 3; break;
-  case VK_FORMAT_R8G8B8_SSCALED: result = 3; break;
-  case VK_FORMAT_R8G8B8_UINT: result = 3; break;
-  case VK_FORMAT_R8G8B8_SINT: result = 3; break;
-  case VK_FORMAT_R8G8B8_SRGB: result = 3; break;
-  case VK_FORMAT_B8G8R8_UNORM: result = 3; break;
-  case VK_FORMAT_B8G8R8_SNORM: result = 3; break;
-  case VK_FORMAT_B8G8R8_USCALED: result = 3; break;
-  case VK_FORMAT_B8G8R8_SSCALED: result = 3; break;
-  case VK_FORMAT_B8G8R8_UINT: result = 3; break;
-  case VK_FORMAT_B8G8R8_SINT: result = 3; break;
-  case VK_FORMAT_B8G8R8_SRGB: result = 3; break;
-  case VK_FORMAT_R8G8B8A8_UNORM: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_SNORM: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_USCALED: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_SSCALED: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_UINT: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_SINT: result = 4; break;
-  case VK_FORMAT_R8G8B8A8_SRGB: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_UNORM: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_SNORM: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_USCALED: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_SSCALED: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_UINT: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_SINT: result = 4; break;
-  case VK_FORMAT_B8G8R8A8_SRGB: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_UNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_SNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_USCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_SSCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_UINT_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_SINT_PACK32: result = 4; break;
-  case VK_FORMAT_A8B8G8R8_SRGB_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_UNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_SNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_USCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_SSCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_UINT_PACK32: result = 4; break;
-  case VK_FORMAT_A2R10G10B10_SINT_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_UNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_SNORM_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_USCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_SSCALED_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_UINT_PACK32: result = 4; break;
-  case VK_FORMAT_A2B10G10R10_SINT_PACK32: result = 4; break;
-  case VK_FORMAT_R16_UNORM: result = 2; break;
-  case VK_FORMAT_R16_SNORM: result = 2; break;
-  case VK_FORMAT_R16_USCALED: result = 2; break;
-  case VK_FORMAT_R16_SSCALED: result = 2; break;
-  case VK_FORMAT_R16_UINT: result = 2; break;
-  case VK_FORMAT_R16_SINT: result = 2; break;
-  case VK_FORMAT_R16_SFLOAT: result = 2; break;
-  case VK_FORMAT_R16G16_UNORM: result = 4; break;
-  case VK_FORMAT_R16G16_SNORM: result = 4; break;
-  case VK_FORMAT_R16G16_USCALED: result = 4; break;
-  case VK_FORMAT_R16G16_SSCALED: result = 4; break;
-  case VK_FORMAT_R16G16_UINT: result = 4; break;
-  case VK_FORMAT_R16G16_SINT: result = 4; break;
-  case VK_FORMAT_R16G16_SFLOAT: result = 4; break;
-  case VK_FORMAT_R16G16B16_UNORM: result = 6; break;
-  case VK_FORMAT_R16G16B16_SNORM: result = 6; break;
-  case VK_FORMAT_R16G16B16_USCALED: result = 6; break;
-  case VK_FORMAT_R16G16B16_SSCALED: result = 6; break;
-  case VK_FORMAT_R16G16B16_UINT: result = 6; break;
-  case VK_FORMAT_R16G16B16_SINT: result = 6; break;
-  case VK_FORMAT_R16G16B16_SFLOAT: result = 6; break;
-  case VK_FORMAT_R16G16B16A16_UNORM: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_SNORM: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_USCALED: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_SSCALED: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_UINT: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_SINT: result = 8; break;
-  case VK_FORMAT_R16G16B16A16_SFLOAT: result = 8; break;
-  case VK_FORMAT_R32_UINT: result = 4; break;
-  case VK_FORMAT_R32_SINT: result = 4; break;
-  case VK_FORMAT_R32_SFLOAT: result = 4; break;
-  case VK_FORMAT_R32G32_UINT: result = 8; break;
-  case VK_FORMAT_R32G32_SINT: result = 8; break;
-  case VK_FORMAT_R32G32_SFLOAT: result = 8; break;
-  case VK_FORMAT_R32G32B32_UINT: result = 12; break;
-  case VK_FORMAT_R32G32B32_SINT: result = 12; break;
-  case VK_FORMAT_R32G32B32_SFLOAT: result = 12; break;
-  case VK_FORMAT_R32G32B32A32_UINT: result = 16; break;
-  case VK_FORMAT_R32G32B32A32_SINT: result = 16; break;
-  case VK_FORMAT_R32G32B32A32_SFLOAT: result = 16; break;
-  case VK_FORMAT_R64_UINT: result = 8; break;
-  case VK_FORMAT_R64_SINT: result = 8; break;
-  case VK_FORMAT_R64_SFLOAT: result = 8; break;
-  case VK_FORMAT_R64G64_UINT: result = 16; break;
-  case VK_FORMAT_R64G64_SINT: result = 16; break;
-  case VK_FORMAT_R64G64_SFLOAT: result = 16; break;
-  case VK_FORMAT_R64G64B64_UINT: result = 24; break;
-  case VK_FORMAT_R64G64B64_SINT: result = 24; break;
-  case VK_FORMAT_R64G64B64_SFLOAT: result = 24; break;
-  case VK_FORMAT_R64G64B64A64_UINT: result = 32; break;
-  case VK_FORMAT_R64G64B64A64_SINT: result = 32; break;
-  case VK_FORMAT_R64G64B64A64_SFLOAT: result = 32; break;
-  case VK_FORMAT_B10G11R11_UFLOAT_PACK32: result = 4; break;
-  case VK_FORMAT_E5B9G9R9_UFLOAT_PACK32: result = 4; break;
+    case VK_FORMAT_UNDEFINED:
+      result = 0;
+      break;
+    case VK_FORMAT_R4G4_UNORM_PACK8:
+      result = 1;
+      break;
+    case VK_FORMAT_R4G4B4A4_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_B4G4R4A4_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_R5G6B5_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_B5G6R5_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_R5G5B5A1_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_B5G5R5A1_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_A1R5G5B5_UNORM_PACK16:
+      result = 2;
+      break;
+    case VK_FORMAT_R8_UNORM:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_SNORM:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_USCALED:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_SSCALED:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_UINT:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_SINT:
+      result = 1;
+      break;
+    case VK_FORMAT_R8_SRGB:
+      result = 1;
+      break;
+    case VK_FORMAT_R8G8_UNORM:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_SNORM:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_USCALED:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_SSCALED:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_UINT:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_SINT:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8_SRGB:
+      result = 2;
+      break;
+    case VK_FORMAT_R8G8B8_UNORM:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_SNORM:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_USCALED:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_SSCALED:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_UINT:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_SINT:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8_SRGB:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_UNORM:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_SNORM:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_USCALED:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_SSCALED:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_UINT:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_SINT:
+      result = 3;
+      break;
+    case VK_FORMAT_B8G8R8_SRGB:
+      result = 3;
+      break;
+    case VK_FORMAT_R8G8B8A8_UNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_SNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_USCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_SSCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_UINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_SINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R8G8B8A8_SRGB:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_UNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_SNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_USCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_SSCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_UINT:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_SINT:
+      result = 4;
+      break;
+    case VK_FORMAT_B8G8R8A8_SRGB:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_UNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_SNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_USCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_SSCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_UINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_SINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_SNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_USCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_SSCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_UINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2R10G10B10_SINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_SNORM_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_USCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_SSCALED_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_UINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_A2B10G10R10_SINT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_R16_UNORM:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_SNORM:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_USCALED:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_SSCALED:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_UINT:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_SINT:
+      result = 2;
+      break;
+    case VK_FORMAT_R16_SFLOAT:
+      result = 2;
+      break;
+    case VK_FORMAT_R16G16_UNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_SNORM:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_USCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_SSCALED:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_UINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_SINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16_SFLOAT:
+      result = 4;
+      break;
+    case VK_FORMAT_R16G16B16_UNORM:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_SNORM:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_USCALED:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_SSCALED:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_UINT:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_SINT:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16_SFLOAT:
+      result = 6;
+      break;
+    case VK_FORMAT_R16G16B16A16_UNORM:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_SNORM:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_USCALED:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_SSCALED:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_UINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_SINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R16G16B16A16_SFLOAT:
+      result = 8;
+      break;
+    case VK_FORMAT_R32_UINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R32_SINT:
+      result = 4;
+      break;
+    case VK_FORMAT_R32_SFLOAT:
+      result = 4;
+      break;
+    case VK_FORMAT_R32G32_UINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R32G32_SINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R32G32_SFLOAT:
+      result = 8;
+      break;
+    case VK_FORMAT_R32G32B32_UINT:
+      result = 12;
+      break;
+    case VK_FORMAT_R32G32B32_SINT:
+      result = 12;
+      break;
+    case VK_FORMAT_R32G32B32_SFLOAT:
+      result = 12;
+      break;
+    case VK_FORMAT_R32G32B32A32_UINT:
+      result = 16;
+      break;
+    case VK_FORMAT_R32G32B32A32_SINT:
+      result = 16;
+      break;
+    case VK_FORMAT_R32G32B32A32_SFLOAT:
+      result = 16;
+      break;
+    case VK_FORMAT_R64_UINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R64_SINT:
+      result = 8;
+      break;
+    case VK_FORMAT_R64_SFLOAT:
+      result = 8;
+      break;
+    case VK_FORMAT_R64G64_UINT:
+      result = 16;
+      break;
+    case VK_FORMAT_R64G64_SINT:
+      result = 16;
+      break;
+    case VK_FORMAT_R64G64_SFLOAT:
+      result = 16;
+      break;
+    case VK_FORMAT_R64G64B64_UINT:
+      result = 24;
+      break;
+    case VK_FORMAT_R64G64B64_SINT:
+      result = 24;
+      break;
+    case VK_FORMAT_R64G64B64_SFLOAT:
+      result = 24;
+      break;
+    case VK_FORMAT_R64G64B64A64_UINT:
+      result = 32;
+      break;
+    case VK_FORMAT_R64G64B64A64_SINT:
+      result = 32;
+      break;
+    case VK_FORMAT_R64G64B64A64_SFLOAT:
+      result = 32;
+      break;
+    case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
+      result = 4;
+      break;
+    case VK_FORMAT_E5B9G9R9_UFLOAT_PACK32:
+      result = 4;
+      break;
 
-  default:
-    break;
+    default:
+      break;
   }
   return result;
 }
 #endif
 
-int main(int argn, char** argv)
-{
+int main(int argn, char** argv) {
   SpvReflectShaderModule module = {};
-  SpvReflectResult result = spvReflectCreateShaderModule(sizeof(k_sample_spv), k_sample_spv, &module);
+  SpvReflectResult result =
+      spvReflectCreateShaderModule(sizeof(k_sample_spv), k_sample_spv, &module);
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
   uint32_t count = 0;
@@ -155,7 +403,8 @@ int main(int argn, char** argv)
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
   std::vector<SpvReflectInterfaceVariable*> input_vars(count);
-  result = spvReflectEnumerateInputVariables(&module, &count, input_vars.data());
+  result =
+      spvReflectEnumerateInputVariables(&module, &count, input_vars.data());
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
   count = 0;
@@ -163,7 +412,8 @@ int main(int argn, char** argv)
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
   std::vector<SpvReflectInterfaceVariable*> output_vars(count);
-  result = spvReflectEnumerateOutputVariables(&module, &count, output_vars.data());
+  result =
+      spvReflectEnumerateOutputVariables(&module, &count, output_vars.data());
   assert(result == SPV_REFLECT_RESULT_SUCCESS);
 
 #if defined(SPIRV_REFLECT_HAS_VULKAN_H)
@@ -177,19 +427,21 @@ int main(int argn, char** argv)
     //   bound to VB slot 0.
     // - Each vertex's attribute are laid out in ascending order by location.
     // - The format of each attribute matches its usage in the shader;
-    //   float4 -> VK_FORMAT_R32G32B32A32_FLOAT, etc. No attribute compression is applied.
+    //   float4 -> VK_FORMAT_R32G32B32A32_FLOAT, etc. No attribute compression
+    //   is applied.
     // - All attributes are provided per-vertex, not per-instance.
     VkVertexInputBindingDescription binding_description = {};
     binding_description.binding = 0;
     binding_description.stride = 0;  // computed below
     binding_description.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-    VkPipelineVertexInputStateCreateInfo vertex_input_state_create_info = { VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO };
+    VkPipelineVertexInputStateCreateInfo vertex_input_state_create_info = {
+        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
     std::vector<VkVertexInputAttributeDescription> attribute_descriptions;
     attribute_descriptions.reserve(input_vars.size());
     for (size_t i_var = 0; i_var < input_vars.size(); ++i_var) {
       const SpvReflectInterfaceVariable& refl_var = *(input_vars[i_var]);
       // ignore built-in variables
-      if (refl_var.decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) { 
+      if (refl_var.decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) {
         continue;
       }
       VkVertexInputAttributeDescription attr_desc{};
@@ -200,35 +452,42 @@ int main(int argn, char** argv)
       attribute_descriptions.push_back(attr_desc);
     }
     // Sort attributes by location
-    std::sort(std::begin(attribute_descriptions), std::end(attribute_descriptions),
-      [](const VkVertexInputAttributeDescription& a, const VkVertexInputAttributeDescription& b) {
-      return a.location < b.location; });
+    std::sort(std::begin(attribute_descriptions),
+              std::end(attribute_descriptions),
+              [](const VkVertexInputAttributeDescription& a,
+                 const VkVertexInputAttributeDescription& b) {
+                return a.location < b.location;
+              });
     // Compute final offsets of each attribute, and total vertex stride.
     for (auto& attribute : attribute_descriptions) {
       uint32_t format_size = FormatSize(attribute.format);
       attribute.offset = binding_description.stride;
       binding_description.stride += format_size;
     }
-    // Nothing further is done with attribute_descriptions or binding_description
-    // in this sample. A real application would probably derive this information from its
-    // mesh format(s); a similar mechanism could be used to ensure mesh/shader compatibility.
+    // Nothing further is done with attribute_descriptions or
+    // binding_description in this sample. A real application would probably
+    // derive this information from its mesh format(s); a similar mechanism
+    // could be used to ensure mesh/shader compatibility.
   }
 #endif
 
   // Log the interface variables to stdout
-  const char* t  = "  ";
+  const char* t = "  ";
   const char* tt = "    ";
 
   PrintModuleInfo(std::cout, module);
   std::cout << "\n\n";
 
-  std::cout << "Input variables:" << "\n";
+  std::cout << "Input variables:"
+            << "\n";
   for (size_t index = 0; index < input_vars.size(); ++index) {
     auto p_var = input_vars[index];
 
-    // input variables can also be retrieved directly from the module, by location
-    // (unless the location is (uint32_t)-1, as is the case with built-in inputs)
-    auto p_var2 = spvReflectGetInputVariableByLocation(&module, p_var->location, &result);
+    // input variables can also be retrieved directly from the module, by
+    // location (unless the location is (uint32_t)-1, as is the case with
+    // built-in inputs)
+    auto p_var2 =
+        spvReflectGetInputVariableByLocation(&module, p_var->location, &result);
     if (p_var->location == UINT32_MAX) {
       assert(result == SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
       assert(p_var2 == nullptr);
@@ -238,8 +497,10 @@ int main(int argn, char** argv)
     }
     (void)p_var2;
 
-    // input variables can also be retrieved directly from the module, by semantic (if present)
-    p_var2 = spvReflectGetInputVariableBySemantic(&module, p_var->semantic, &result);
+    // input variables can also be retrieved directly from the module, by
+    // semantic (if present)
+    p_var2 =
+        spvReflectGetInputVariableBySemantic(&module, p_var->semantic, &result);
     if (!p_var->semantic) {
       assert(result == SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
       assert(p_var2 == nullptr);
@@ -252,18 +513,22 @@ int main(int argn, char** argv)
     }
     (void)p_var2;
 
-    std::cout << t << index << ":" << "\n";
+    std::cout << t << index << ":"
+              << "\n";
     PrintInterfaceVariable(std::cout, module.source_language, *p_var, tt);
     std::cout << "\n\n";
   }
 
-  std::cout << "Output variables:" << "\n";
+  std::cout << "Output variables:"
+            << "\n";
   for (size_t index = 0; index < output_vars.size(); ++index) {
     auto p_var = output_vars[index];
 
-    // output variables can also be retrieved directly from the module, by location
-    // (unless the location is (uint32_t)-1, as is the case with built-in outputs)
-    auto p_var2 = spvReflectGetOutputVariableByLocation(&module, p_var->location, &result);
+    // output variables can also be retrieved directly from the module, by
+    // location (unless the location is (uint32_t)-1, as is the case with
+    // built-in outputs)
+    auto p_var2 = spvReflectGetOutputVariableByLocation(
+        &module, p_var->location, &result);
     if (p_var->location == UINT32_MAX) {
       assert(result == SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
       assert(p_var2 == nullptr);
@@ -273,8 +538,10 @@ int main(int argn, char** argv)
     }
     (void)p_var2;
 
-    // output variables can also be retrieved directly from the module, by semantic (if present)
-    p_var2 = spvReflectGetOutputVariableBySemantic(&module, p_var->semantic, &result);
+    // output variables can also be retrieved directly from the module, by
+    // semantic (if present)
+    p_var2 = spvReflectGetOutputVariableBySemantic(&module, p_var->semantic,
+                                                   &result);
     if (!p_var->semantic) {
       assert(result == SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
       assert(p_var2 == nullptr);
@@ -287,7 +554,8 @@ int main(int argn, char** argv)
     }
     (void)p_var2;
 
-    std::cout << t << index << ":" << "\n";
+    std::cout << t << index << ":"
+              << "\n";
     PrintInterfaceVariable(std::cout, module.source_language, *p_var, tt);
     std::cout << "\n\n";
   }

--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,12 @@
 /*
  Copyright 2017-2018 Google Inc.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,50 +15,72 @@
 */
 
 #if defined(WIN32)
-  #define _CRTDBG_MAP_ALLOC  
-  #include <stdlib.h>
-  #include <crtdbg.h>
+#define _CRTDBG_MAP_ALLOC
+#include <crtdbg.h>
+#include <stdlib.h>
 #endif
 
 #include <cassert>
 #include <cstring>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-#include "spirv_reflect.h"
-#include "examples/arg_parser.h"
 #include "common/output_stream.h"
-
+#include "examples/arg_parser.h"
+#include "spirv_reflect.h"
 
 // =================================================================================================
 // PrintUsage()
 // =================================================================================================
-void PrintUsage()
-{
+void PrintUsage() {
   std::cout
-    << "Usage: spirv-reflect [OPTIONS] path/to/SPIR-V/bytecode.spv" << std::endl
-    << "Prints a summary of the reflection data extracted from SPIR-V bytecode." << std::endl
-    << "Options:" << std::endl
-    << " --help                   Display this message" << std::endl
-    << " -y,--yaml                Format output as YAML. [default: disabled]" << std::endl
-    << " -v VERBOSITY             Specify output verbosity (YAML output only):" << std::endl
-    << "                          0: shader info, block variables, interface variables," << std::endl
-    << "                             descriptor bindings. No type descriptions. [default]" << std::endl
-    << "                          1: Everything above, plus type descriptions." << std::endl
-    << "                          2: Everything above, plus SPIR-V bytecode and all internal" << std::endl
-    << "                             type descriptions. If you're not working on SPIRV-Reflect" << std::endl
-    << "                             itself, you probably don't want this." << std::endl
-    << "-e,--entrypoint           Prints the entry point found in shader module." << std::endl
-    << "-s,--stage                Prints the Vulkan shader stage found in shader module." << std::endl
-    << "-f,--file                 Prints the source file found in shader module." << std::endl
-    << "-fcb,--flatten_cbuffers   Flatten constant buffers on non-YAML output." << std::endl;
+      << "Usage: spirv-reflect [OPTIONS] path/to/SPIR-V/bytecode.spv"
+      << std::endl
+      << "Prints a summary of the reflection data extracted from SPIR-V "
+         "bytecode."
+      << std::endl
+      << "Options:" << std::endl
+      << " --help                   Display this message" << std::endl
+      << " -y,--yaml                Format output as YAML. [default: disabled]"
+      << std::endl
+      << " -v VERBOSITY             Specify output verbosity (YAML output "
+         "only):"
+      << std::endl
+      << "                          0: shader info, block variables, interface "
+         "variables,"
+      << std::endl
+      << "                             descriptor bindings. No type "
+         "descriptions. [default]"
+      << std::endl
+      << "                          1: Everything above, plus type "
+         "descriptions."
+      << std::endl
+      << "                          2: Everything above, plus SPIR-V bytecode "
+         "and all internal"
+      << std::endl
+      << "                             type descriptions. If you're not "
+         "working on SPIRV-Reflect"
+      << std::endl
+      << "                             itself, you probably don't want this."
+      << std::endl
+      << "-e,--entrypoint           Prints the entry point found in shader "
+         "module."
+      << std::endl
+      << "-s,--stage                Prints the Vulkan shader stage found in "
+         "shader module."
+      << std::endl
+      << "-f,--file                 Prints the source file found in shader "
+         "module."
+      << std::endl
+      << "-fcb,--flatten_cbuffers   Flatten constant buffers on non-YAML "
+         "output."
+      << std::endl;
 }
 
 // =================================================================================================
 // main()
 // =================================================================================================
-int main(int argn, char** argv)
-{
+int main(int argn, char** argv) {
   ArgParser arg_parser;
   arg_parser.AddFlag("h", "help", "");
   arg_parser.AddFlag("y", "yaml", "");
@@ -82,20 +104,21 @@ int main(int argn, char** argv)
   int yaml_verbosity = 0;
   arg_parser.GetInt("v", "verbosity", &yaml_verbosity);
 
-	bool print_entry_point = arg_parser.GetFlag("e", "entrypoint");
+  bool print_entry_point = arg_parser.GetFlag("e", "entrypoint");
   bool print_shader_stage = arg_parser.GetFlag("s", "stage");
   bool print_source_file = arg_parser.GetFlag("f", "file");
   bool flatten_cbuffers = arg_parser.GetFlag("fcb", "flatten_cbuffers");
 
-	std::string input_spv_path;
-	if (!arg_parser.GetArg(0, &input_spv_path)) {
+  std::string input_spv_path;
+  if (!arg_parser.GetArg(0, &input_spv_path)) {
     std::cerr << "ERROR: no SPIR-V file specified" << std::endl;
     return EXIT_FAILURE;
-	}
-			
+  }
+
   std::ifstream spv_ifstream(input_spv_path.c_str(), std::ios::binary);
   if (!spv_ifstream.is_open()) {
-    std::cerr << "ERROR: could not open '" << input_spv_path << "' for reading" << std::endl;
+    std::cerr << "ERROR: could not open '" << input_spv_path << "' for reading"
+              << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -110,11 +133,11 @@ int main(int argn, char** argv)
     spv_reflect::ShaderModule reflection(spv_data.size(), spv_data.data());
     if (reflection.GetResult() != SPV_REFLECT_RESULT_SUCCESS) {
       std::cerr << "ERROR: could not process '" << input_spv_path
-        << "' (is it a valid SPIR-V bytecode?)" << std::endl;
+                << "' (is it a valid SPIR-V bytecode?)" << std::endl;
       return EXIT_FAILURE;
     }
 
-		if (print_entry_point || print_shader_stage || print_source_file) {
+    if (print_entry_point || print_shader_stage || print_source_file) {
       size_t printed_count = 0;
       if (print_entry_point) {
         std::cout << reflection.GetEntryPointName();
@@ -132,21 +155,22 @@ int main(int argn, char** argv)
         if (printed_count > 0) {
           std::cout << ";";
         }
-        std::cout << (reflection.GetSourceFile() != NULL ? reflection.GetSourceFile() : "");
+        std::cout << (reflection.GetSourceFile() != NULL
+                          ? reflection.GetSourceFile()
+                          : "");
       }
 
       std::cout << std::endl;
-		}
-		else {
-			if (output_as_yaml) {
-				SpvReflectToYaml yamlizer(reflection.GetShaderModule(), yaml_verbosity);
-				std::cout << yamlizer;
-			} else {
+    } else {
+      if (output_as_yaml) {
+        SpvReflectToYaml yamlizer(reflection.GetShaderModule(), yaml_verbosity);
+        std::cout << yamlizer;
+      } else {
         WriteReflection(reflection, flatten_cbuffers, std::cout);
         std::cout << std::endl;
-				std::cout << std::endl;
-			}
-		}
+        std::cout << std::endl;
+      }
+    }
   }
 
   return EXIT_SUCCESS;

--- a/tests/cpp/noncopyable/main.cpp
+++ b/tests/cpp/noncopyable/main.cpp
@@ -1,7 +1,6 @@
 #include "spirv_reflect.h"
 
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
   spv_reflect::ShaderModule shaderModule;
   shaderModule = spv_reflect::ShaderModule();
   return 0;

--- a/tests/test-spirv-reflect.cpp
+++ b/tests/test-spirv-reflect.cpp
@@ -1,14 +1,13 @@
-#include "../common/output_stream.h"
-#include "spirv_reflect.h"
-
-#include "gtest/gtest.h"
-
 #include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <regex>
 #include <sstream>
 #include <string>
+
+#include "../common/output_stream.h"
+#include "gtest/gtest.h"
+#include "spirv_reflect.h"
 
 #if defined(_MSC_VER)
 #include <direct.h>
@@ -74,13 +73,13 @@ TEST(SpirvReflectTestCase, SourceLanguage) {
                "");
 }
 
-class SpirvReflectTest : public ::testing::TestWithParam<const char *> {
-public:
+class SpirvReflectTest : public ::testing::TestWithParam<const char*> {
+ public:
   // optional: initialize static data to be shared by all tests in this test
   // case. Note that for parameterized tests, the specific parameter value is a
   // non-static member data
   static void SetUpTestCase() {
-    FILE *f = fopen("tests/glsl/built_in_format.spv", "r");
+    FILE* f = fopen("tests/glsl/built_in_format.spv", "r");
     if (!f) {
       posix_chdir("..");
       f = fopen("tests/glsl/built_in_format.spv", "r");
@@ -92,7 +91,7 @@ public:
   }
   static void TearDownTestCase() {}
 
-protected:
+ protected:
   SpirvReflectTest() {
     // set-up work for each test
   }
@@ -111,7 +110,7 @@ protected:
     std::streampos spirv_file_nbytes = spirv_file.tellg();
     spirv_file.seekg(0);
     spirv_.resize(spirv_file_nbytes);
-    spirv_file.read(reinterpret_cast<char *>(spirv_.data()), spirv_.size());
+    spirv_file.read(reinterpret_cast<char*>(spirv_.data()), spirv_.size());
 
     SpvReflectResult result =
         spvReflectCreateShaderModule(spirv_.size(), spirv_.data(), &module_);
@@ -158,13 +157,13 @@ TEST_P(SpirvReflectTest, GetDescriptorBinding) {
   result =
       spvReflectEnumerateDescriptorBindings(&module_, &binding_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectDescriptorBinding *> bindings(binding_count);
+  std::vector<SpvReflectDescriptorBinding*> bindings(binding_count);
   result = spvReflectEnumerateDescriptorBindings(&module_, &binding_count,
                                                  bindings.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *db : bindings) {
-    const SpvReflectDescriptorBinding *also_db =
+  for (const auto* db : bindings) {
+    const SpvReflectDescriptorBinding* also_db =
         spvReflectGetDescriptorBinding(&module_, db->binding, db->set, &result);
     EXPECT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
     EXPECT_EQ(db, also_db);
@@ -177,18 +176,17 @@ TEST_P(SpirvReflectTest, EnumerateDescriptorBindings_Errors) {
       spvReflectEnumerateDescriptorBindings(nullptr, &binding_count, nullptr),
       SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL binding count
-  EXPECT_EQ(
-    spvReflectEnumerateDescriptorBindings(&module_, nullptr, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateDescriptorBindings(&module_, nullptr, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // binding count / module binding count mismatch
   EXPECT_EQ(
-    spvReflectEnumerateDescriptorBindings(&module_, &binding_count, nullptr),
-    SPV_REFLECT_RESULT_SUCCESS);
-  uint32_t bad_binding_count = binding_count+1;
+      spvReflectEnumerateDescriptorBindings(&module_, &binding_count, nullptr),
+      SPV_REFLECT_RESULT_SUCCESS);
+  uint32_t bad_binding_count = binding_count + 1;
   std::vector<SpvReflectDescriptorBinding*> bindings(bad_binding_count);
-  EXPECT_EQ(
-    spvReflectEnumerateDescriptorBindings(&module_, &bad_binding_count, bindings.data()),
-    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
+  EXPECT_EQ(spvReflectEnumerateDescriptorBindings(&module_, &bad_binding_count,
+                                                  bindings.data()),
+            SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
 }
 TEST_P(SpirvReflectTest, GetDescriptorBinding_Errors) {
   SpvReflectResult result;
@@ -197,12 +195,16 @@ TEST_P(SpirvReflectTest, GetDescriptorBinding_Errors) {
   EXPECT_EQ(spvReflectGetDescriptorBinding(nullptr, 0, 0, &result), nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // Invalid binding number
-  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0xdeadbeef, 0, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0xdeadbeef, 0, &result), nullptr);
+  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0xdeadbeef, 0, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0xdeadbeef, 0, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
   // Invalid set number
-  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0, 0xdeadbeef, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0, 0xdeadbeef, &result), nullptr);
+  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0, 0xdeadbeef, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetDescriptorBinding(&module_, 0, 0xdeadbeef, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -211,12 +213,12 @@ TEST_P(SpirvReflectTest, GetDescriptorSet) {
   SpvReflectResult result;
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectDescriptorSet *> sets(set_count);
+  std::vector<SpvReflectDescriptorSet*> sets(set_count);
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, sets.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *ds : sets) {
-    const SpvReflectDescriptorSet *also_ds =
+  for (const auto* ds : sets) {
+    const SpvReflectDescriptorSet* also_ds =
         spvReflectGetDescriptorSet(&module_, ds->set, &result);
     EXPECT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
     EXPECT_EQ(ds, also_ds);
@@ -225,22 +227,19 @@ TEST_P(SpirvReflectTest, GetDescriptorSet) {
 TEST_P(SpirvReflectTest, EnumerateDescriptorSets_Errors) {
   uint32_t set_count = 0;
   // NULL module
-  EXPECT_EQ(
-    spvReflectEnumerateDescriptorSets(nullptr, &set_count, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateDescriptorSets(nullptr, &set_count, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL set count
-  EXPECT_EQ(
-    spvReflectEnumerateDescriptorSets(&module_, nullptr, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateDescriptorSets(&module_, nullptr, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // set count / module set count mismatch
-  EXPECT_EQ(
-    spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr),
-    SPV_REFLECT_RESULT_SUCCESS);
-  uint32_t bad_set_count = set_count+1;
+  EXPECT_EQ(spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr),
+            SPV_REFLECT_RESULT_SUCCESS);
+  uint32_t bad_set_count = set_count + 1;
   std::vector<SpvReflectDescriptorSet*> sets(bad_set_count);
   EXPECT_EQ(
-    spvReflectEnumerateDescriptorSets(&module_, &bad_set_count, sets.data()),
-    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
+      spvReflectEnumerateDescriptorSets(&module_, &bad_set_count, sets.data()),
+      SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
 }
 TEST_P(SpirvReflectTest, GetDescriptorSet_Errors) {
   SpvReflectResult result;
@@ -259,12 +258,12 @@ TEST_P(SpirvReflectTest, GetInputVariableByLocation) {
   SpvReflectResult result;
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectInterfaceVariable *> ivars(iv_count);
+  std::vector<SpvReflectInterfaceVariable*> ivars(iv_count);
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, ivars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *iv : ivars) {
-    const SpvReflectInterfaceVariable *also_iv =
+  for (const auto* iv : ivars) {
+    const SpvReflectInterfaceVariable* also_iv =
         spvReflectGetInputVariableByLocation(&module_, iv->location, &result);
     if (iv->location == UINT32_MAX) {
       // Not all elements have valid locations.
@@ -279,36 +278,37 @@ TEST_P(SpirvReflectTest, GetInputVariableByLocation) {
 TEST_P(SpirvReflectTest, EnumerateInputVariables_Errors) {
   uint32_t var_count = 0;
   // NULL module
-  EXPECT_EQ(
-    spvReflectEnumerateInputVariables(nullptr, &var_count, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateInputVariables(nullptr, &var_count, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL var count
-  EXPECT_EQ(
-    spvReflectEnumerateInputVariables(&module_, nullptr, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateInputVariables(&module_, nullptr, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // var count / module var count mismatch
-  EXPECT_EQ(
-    spvReflectEnumerateInputVariables(&module_, &var_count, nullptr),
-    SPV_REFLECT_RESULT_SUCCESS);
-  uint32_t bad_var_count = var_count+1;
+  EXPECT_EQ(spvReflectEnumerateInputVariables(&module_, &var_count, nullptr),
+            SPV_REFLECT_RESULT_SUCCESS);
+  uint32_t bad_var_count = var_count + 1;
   std::vector<SpvReflectInterfaceVariable*> vars(bad_var_count);
   EXPECT_EQ(
-    spvReflectEnumerateInputVariables(&module_, &bad_var_count, vars.data()),
-    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
+      spvReflectEnumerateInputVariables(&module_, &bad_var_count, vars.data()),
+      SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
 }
 TEST_P(SpirvReflectTest, GetInputVariableByLocation_Errors) {
   SpvReflectResult result;
-    // NULL module
+  // NULL module
   EXPECT_EQ(spvReflectGetInputVariableByLocation(nullptr, 0, nullptr), nullptr);
   EXPECT_EQ(spvReflectGetInputVariableByLocation(nullptr, 0, &result), nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // explicitly invalid location (UINT32_MAX is *always* not found)
-  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, UINT32_MAX, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, UINT32_MAX, &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, UINT32_MAX, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, UINT32_MAX, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
   // implicitly invalid location (0xdeadbeef is potentially valid)
-  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, 0xdeadbeef, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, 0xdeadbeef, &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, 0xdeadbeef, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableByLocation(&module_, 0xdeadbeef, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -317,12 +317,12 @@ TEST_P(SpirvReflectTest, GetInputVariableBySemantic) {
   SpvReflectResult result;
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectInterfaceVariable *> ivars(iv_count);
+  std::vector<SpvReflectInterfaceVariable*> ivars(iv_count);
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, ivars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *iv : ivars) {
-    const SpvReflectInterfaceVariable *also_iv =
+  for (const auto* iv : ivars) {
+    const SpvReflectInterfaceVariable* also_iv =
         spvReflectGetInputVariableBySemantic(&module_, iv->semantic, &result);
     if (iv->semantic == nullptr) {
       // Not all elements have valid semantics
@@ -341,20 +341,30 @@ TEST_P(SpirvReflectTest, GetInputVariableBySemantic) {
 TEST_P(SpirvReflectTest, GetInputVariableBySemantic_Errors) {
   SpvReflectResult result;
   // NULL module
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(nullptr, nullptr, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(nullptr, nullptr, &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(nullptr, nullptr, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(nullptr, nullptr, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL semantic
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, nullptr, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, nullptr, &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, nullptr, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, nullptr, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // empty semantic ("" is explicitly not found)
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "", nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "", &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "", nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "", &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
   // implicitly invalid semantic
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "SV_PLAUSIBLE_BUT_INVALID", nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetInputVariableBySemantic(&module_, "SV_PLAUSIBLE_BUT_INVALID", &result), nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(
+                &module_, "SV_PLAUSIBLE_BUT_INVALID", nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetInputVariableBySemantic(
+                &module_, "SV_PLAUSIBLE_BUT_INVALID", &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -363,13 +373,13 @@ TEST_P(SpirvReflectTest, GetOutputVariableByLocation) {
   SpvReflectResult result;
   result = spvReflectEnumerateOutputVariables(&module_, &ov_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectInterfaceVariable *> ovars(ov_count);
+  std::vector<SpvReflectInterfaceVariable*> ovars(ov_count);
   result =
       spvReflectEnumerateOutputVariables(&module_, &ov_count, ovars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *ov : ovars) {
-    const SpvReflectInterfaceVariable *also_ov =
+  for (const auto* ov : ovars) {
+    const SpvReflectInterfaceVariable* also_ov =
         spvReflectGetOutputVariableByLocation(&module_, ov->location, &result);
     if (ov->location == UINT32_MAX) {
       // Not all elements have valid locations.
@@ -384,36 +394,43 @@ TEST_P(SpirvReflectTest, GetOutputVariableByLocation) {
 TEST_P(SpirvReflectTest, EnumerateOutputVariables_Errors) {
   uint32_t var_count = 0;
   // NULL module
-  EXPECT_EQ(
-    spvReflectEnumerateOutputVariables(nullptr, &var_count, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateOutputVariables(nullptr, &var_count, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL var count
-  EXPECT_EQ(
-    spvReflectEnumerateOutputVariables(&module_, nullptr, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumerateOutputVariables(&module_, nullptr, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // var count / module var count mismatch
-  EXPECT_EQ(
-    spvReflectEnumerateOutputVariables(&module_, &var_count, nullptr),
-    SPV_REFLECT_RESULT_SUCCESS);
-  uint32_t bad_var_count = var_count+1;
+  EXPECT_EQ(spvReflectEnumerateOutputVariables(&module_, &var_count, nullptr),
+            SPV_REFLECT_RESULT_SUCCESS);
+  uint32_t bad_var_count = var_count + 1;
   std::vector<SpvReflectInterfaceVariable*> vars(bad_var_count);
   EXPECT_EQ(
-    spvReflectEnumerateOutputVariables(&module_, &bad_var_count, vars.data()),
-    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
+      spvReflectEnumerateOutputVariables(&module_, &bad_var_count, vars.data()),
+      SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
 }
 TEST_P(SpirvReflectTest, GetOutputVariableByLocation_Errors) {
   SpvReflectResult result;
   // NULL module
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(nullptr, 0, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(nullptr, 0, &result), nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableByLocation(nullptr, 0, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableByLocation(nullptr, 0, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // explicitly invalid location (UINT32_MAX is *always* not found)
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(&module_, UINT32_MAX, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(&module_, UINT32_MAX, &result), nullptr);
+  EXPECT_EQ(
+      spvReflectGetOutputVariableByLocation(&module_, UINT32_MAX, nullptr),
+      nullptr);
+  EXPECT_EQ(
+      spvReflectGetOutputVariableByLocation(&module_, UINT32_MAX, &result),
+      nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
   // implicitly invalid location (0xdeadbeef is potentially valid)
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(&module_, 0xdeadbeef, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableByLocation(&module_, 0xdeadbeef, &result), nullptr);
+  EXPECT_EQ(
+      spvReflectGetOutputVariableByLocation(&module_, 0xdeadbeef, nullptr),
+      nullptr);
+  EXPECT_EQ(
+      spvReflectGetOutputVariableByLocation(&module_, 0xdeadbeef, &result),
+      nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -422,13 +439,13 @@ TEST_P(SpirvReflectTest, GetOutputVariableBySemantic) {
   SpvReflectResult result;
   result = spvReflectEnumerateOutputVariables(&module_, &ov_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectInterfaceVariable *> ovars(ov_count);
+  std::vector<SpvReflectInterfaceVariable*> ovars(ov_count);
   result =
       spvReflectEnumerateOutputVariables(&module_, &ov_count, ovars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  for (const auto *ov : ovars) {
-    const SpvReflectInterfaceVariable *also_ov =
+  for (const auto* ov : ovars) {
+    const SpvReflectInterfaceVariable* also_ov =
         spvReflectGetOutputVariableBySemantic(&module_, ov->semantic, &result);
     if (ov->semantic == nullptr) {
       // Not all elements have valid semantics
@@ -447,20 +464,30 @@ TEST_P(SpirvReflectTest, GetOutputVariableBySemantic) {
 TEST_P(SpirvReflectTest, GetOutputVariableBySemantic_Errors) {
   SpvReflectResult result;
   // NULL module
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(nullptr, nullptr, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(nullptr, nullptr, &result), nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(nullptr, nullptr, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(nullptr, nullptr, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL semantic
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, nullptr, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, nullptr, &result), nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, nullptr, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, nullptr, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // empty semantic ("" is explicitly not found)
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "", nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "", &result), nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "", nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "", &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
   // implicitly invalid semantic
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "SV_PLAUSIBLE_BUT_INVALID", nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(&module_, "SV_PLAUSIBLE_BUT_INVALID", &result), nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(
+                &module_, "SV_PLAUSIBLE_BUT_INVALID", nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetOutputVariableBySemantic(
+                &module_, "SV_PLAUSIBLE_BUT_INVALID", &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -470,14 +497,14 @@ TEST_P(SpirvReflectTest, GetPushConstantBlock) {
   result =
       spvReflectEnumeratePushConstantBlocks(&module_, &block_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
-  std::vector<SpvReflectBlockVariable *> blocks(block_count);
+  std::vector<SpvReflectBlockVariable*> blocks(block_count);
   result = spvReflectEnumeratePushConstantBlocks(&module_, &block_count,
                                                  blocks.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
   for (uint32_t i = 0; i < block_count; ++i) {
-    const SpvReflectBlockVariable *b = blocks[i];
-    const SpvReflectBlockVariable *also_b =
+    const SpvReflectBlockVariable* b = blocks[i];
+    const SpvReflectBlockVariable* also_b =
         spvReflectGetPushConstantBlock(&module_, i, &result);
     EXPECT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
     EXPECT_EQ(b, also_b);
@@ -487,35 +514,36 @@ TEST_P(SpirvReflectTest, EnumeratePushConstantBlocks_Errors) {
   uint32_t block_count = 0;
   // NULL module
   EXPECT_EQ(
-    spvReflectEnumeratePushConstantBlocks(nullptr, &block_count, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+      spvReflectEnumeratePushConstantBlocks(nullptr, &block_count, nullptr),
+      SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL var count
-  EXPECT_EQ(
-    spvReflectEnumeratePushConstantBlocks(&module_, nullptr, nullptr),
-    SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectEnumeratePushConstantBlocks(&module_, nullptr, nullptr),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // var count / module var count mismatch
   EXPECT_EQ(
-    spvReflectEnumeratePushConstantBlocks(&module_, &block_count, nullptr),
-    SPV_REFLECT_RESULT_SUCCESS);
-  uint32_t bad_block_count = block_count+1;
+      spvReflectEnumeratePushConstantBlocks(&module_, &block_count, nullptr),
+      SPV_REFLECT_RESULT_SUCCESS);
+  uint32_t bad_block_count = block_count + 1;
   std::vector<SpvReflectBlockVariable*> blocks(bad_block_count);
-  EXPECT_EQ(
-    spvReflectEnumeratePushConstantBlocks(&module_, &bad_block_count, blocks.data()),
-    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
+  EXPECT_EQ(spvReflectEnumeratePushConstantBlocks(&module_, &bad_block_count,
+                                                  blocks.data()),
+            SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH);
 }
 TEST_P(SpirvReflectTest, GetPushConstantBlock_Errors) {
   uint32_t block_count = 0;
   SpvReflectResult result;
   result =
-    spvReflectEnumeratePushConstantBlocks(&module_, &block_count, nullptr);
+      spvReflectEnumeratePushConstantBlocks(&module_, &block_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   // NULL module
   EXPECT_EQ(spvReflectGetPushConstantBlock(nullptr, 0, nullptr), nullptr);
   EXPECT_EQ(spvReflectGetPushConstantBlock(nullptr, 0, &result), nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // invalid block index
-  EXPECT_EQ(spvReflectGetPushConstantBlock(&module_, block_count, nullptr), nullptr);
-  EXPECT_EQ(spvReflectGetPushConstantBlock(&module_, block_count, &result), nullptr);
+  EXPECT_EQ(spvReflectGetPushConstantBlock(&module_, block_count, nullptr),
+            nullptr);
+  EXPECT_EQ(spvReflectGetPushConstantBlock(&module_, block_count, &result),
+            nullptr);
   EXPECT_EQ(result, SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
 }
 
@@ -526,9 +554,9 @@ TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumber) {
       spvReflectEnumerateDescriptorBindings(&module_, &binding_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   if (binding_count == 0) {
-    return; // can't change binding numbers if there are no bindings!
+    return;  // can't change binding numbers if there are no bindings!
   }
-  std::vector<SpvReflectDescriptorBinding *> bindings(binding_count);
+  std::vector<SpvReflectDescriptorBinding*> bindings(binding_count);
   result = spvReflectEnumerateDescriptorBindings(&module_, &binding_count,
                                                  bindings.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -537,11 +565,11 @@ TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumber) {
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   EXPECT_GT(set_count, 0U);
-  std::vector<SpvReflectDescriptorSet *> sets(set_count);
+  std::vector<SpvReflectDescriptorSet*> sets(set_count);
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, sets.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  SpvReflectDescriptorBinding *b = bindings[0];
+  SpvReflectDescriptorBinding* b = bindings[0];
   const uint32_t new_binding_number = 1000;
   const uint32_t set_number = b->set;
   // Make sure no binding exists at the binding number we're about to change to.
@@ -554,7 +582,7 @@ TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumber) {
       &module_, b, new_binding_number, SPV_REFLECT_SET_NUMBER_DONT_CHANGE);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   // We should now be able to retrieve the binding at the new number
-  const SpvReflectDescriptorBinding *new_binding =
+  const SpvReflectDescriptorBinding* new_binding =
       spvReflectGetDescriptorBinding(&module_, new_binding_number, set_number,
                                      &result);
   ASSERT_NE(new_binding, nullptr);
@@ -566,7 +594,7 @@ TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumber) {
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   EXPECT_EQ(set_count, sets.size());
-  std::vector<SpvReflectDescriptorSet *> new_sets(set_count);
+  std::vector<SpvReflectDescriptorSet*> new_sets(set_count);
   result =
       spvReflectEnumerateDescriptorSets(&module_, &set_count, new_sets.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -577,9 +605,11 @@ TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumber) {
 }
 TEST_P(SpirvReflectTest, ChangeDescriptorBindingNumbers_Errors) {
   // NULL module
-  EXPECT_EQ(spvReflectChangeDescriptorBindingNumbers(nullptr, nullptr, 0, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeDescriptorBindingNumbers(nullptr, nullptr, 0, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL descriptor binding
-  EXPECT_EQ(spvReflectChangeDescriptorBindingNumbers(&module_, nullptr, 0, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeDescriptorBindingNumbers(&module_, nullptr, 0, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
 }
 
 TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber) {
@@ -589,9 +619,9 @@ TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber) {
       spvReflectEnumerateDescriptorBindings(&module_, &binding_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   if (binding_count == 0) {
-    return; // can't change set numbers if there are no bindings!
+    return;  // can't change set numbers if there are no bindings!
   }
-  std::vector<SpvReflectDescriptorBinding *> bindings(binding_count);
+  std::vector<SpvReflectDescriptorBinding*> bindings(binding_count);
   result = spvReflectEnumerateDescriptorBindings(&module_, &binding_count,
                                                  bindings.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -600,11 +630,11 @@ TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber) {
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   EXPECT_GT(set_count, 0U);
-  std::vector<SpvReflectDescriptorSet *> sets(set_count);
+  std::vector<SpvReflectDescriptorSet*> sets(set_count);
   result = spvReflectEnumerateDescriptorSets(&module_, &set_count, sets.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  SpvReflectDescriptorSet *s = sets[0];
+  SpvReflectDescriptorSet* s = sets[0];
 
   const uint32_t new_set_number = 13;
   const uint32_t set_binding_count = s->binding_count;
@@ -616,7 +646,7 @@ TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber) {
   result = spvReflectChangeDescriptorSetNumber(&module_, s, new_set_number);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   // We should now be able to retrieve the set at the new number
-  const SpvReflectDescriptorSet *new_set =
+  const SpvReflectDescriptorSet* new_set =
       spvReflectGetDescriptorSet(&module_, new_set_number, &result);
   ASSERT_NE(new_set, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -633,9 +663,11 @@ TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber) {
 }
 TEST_P(SpirvReflectTest, ChangeDescriptorSetNumber_Errors) {
   // NULL module
-  EXPECT_EQ(spvReflectChangeDescriptorSetNumber(nullptr, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeDescriptorSetNumber(nullptr, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL descriptor set
-  EXPECT_EQ(spvReflectChangeDescriptorSetNumber(&module_, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeDescriptorSetNumber(&module_, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
 }
 
 TEST_P(SpirvReflectTest, ChangeInputVariableLocation) {
@@ -644,13 +676,13 @@ TEST_P(SpirvReflectTest, ChangeInputVariableLocation) {
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   if (iv_count == 0) {
-    return; // can't change variable locations if there are no variables!
+    return;  // can't change variable locations if there are no variables!
   }
-  std::vector<SpvReflectInterfaceVariable *> ivars(iv_count);
+  std::vector<SpvReflectInterfaceVariable*> ivars(iv_count);
   result = spvReflectEnumerateInputVariables(&module_, &iv_count, ivars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  SpvReflectInterfaceVariable *iv = ivars[0];
+  SpvReflectInterfaceVariable* iv = ivars[0];
 
   const uint32_t new_location = 37;
   // Make sure no var exists at the location we're about to change to.
@@ -662,7 +694,7 @@ TEST_P(SpirvReflectTest, ChangeInputVariableLocation) {
   result = spvReflectChangeInputVariableLocation(&module_, iv, new_location);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   // We should now be able to retrieve the variable at its new location
-  const SpvReflectInterfaceVariable *new_iv =
+  const SpvReflectInterfaceVariable* new_iv =
       spvReflectGetInputVariableByLocation(&module_, new_location, &result);
   ASSERT_NE(new_iv, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -677,9 +709,11 @@ TEST_P(SpirvReflectTest, ChangeInputVariableLocation) {
 }
 TEST_P(SpirvReflectTest, ChangeInputVariableLocation_Errors) {
   // NULL module
-  EXPECT_EQ(spvReflectChangeInputVariableLocation(nullptr, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeInputVariableLocation(nullptr, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL variable
-  EXPECT_EQ(spvReflectChangeInputVariableLocation(&module_, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeInputVariableLocation(&module_, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
 }
 
 TEST_P(SpirvReflectTest, ChangeOutputVariableLocation) {
@@ -688,14 +722,14 @@ TEST_P(SpirvReflectTest, ChangeOutputVariableLocation) {
   result = spvReflectEnumerateOutputVariables(&module_, &ov_count, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   if (ov_count == 0) {
-    return; // can't change variable locations if there are no variables!
+    return;  // can't change variable locations if there are no variables!
   }
-  std::vector<SpvReflectInterfaceVariable *> ovars(ov_count);
+  std::vector<SpvReflectInterfaceVariable*> ovars(ov_count);
   result =
       spvReflectEnumerateOutputVariables(&module_, &ov_count, ovars.data());
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
 
-  SpvReflectInterfaceVariable *ov = ovars[0];
+  SpvReflectInterfaceVariable* ov = ovars[0];
 
   const uint32_t new_location = 37;
   // Make sure no var exists at the location we're about to change to.
@@ -707,7 +741,7 @@ TEST_P(SpirvReflectTest, ChangeOutputVariableLocation) {
   result = spvReflectChangeOutputVariableLocation(&module_, ov, new_location);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
   // We should now be able to retrieve the variable at its new location
-  const SpvReflectInterfaceVariable *new_ov =
+  const SpvReflectInterfaceVariable* new_ov =
       spvReflectGetOutputVariableByLocation(&module_, new_location, &result);
   ASSERT_NE(new_ov, nullptr);
   ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
@@ -722,9 +756,11 @@ TEST_P(SpirvReflectTest, ChangeOutputVariableLocation) {
 }
 TEST_P(SpirvReflectTest, ChangeOutputVariableLocation_Errors) {
   // NULL module
-  EXPECT_EQ(spvReflectChangeOutputVariableLocation(nullptr, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeOutputVariableLocation(nullptr, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
   // NULL variable
-  EXPECT_EQ(spvReflectChangeOutputVariableLocation(&module_, nullptr, 0), SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
+  EXPECT_EQ(spvReflectChangeOutputVariableLocation(&module_, nullptr, 0),
+            SPV_REFLECT_RESULT_ERROR_NULL_POINTER);
 }
 
 TEST_P(SpirvReflectTest, CheckYamlOutput) {
@@ -756,7 +792,7 @@ TEST_P(SpirvReflectTest, CheckYamlOutput) {
 }
 
 namespace {
-const std::vector<const char *> all_spirv_paths = {
+const std::vector<const char*> all_spirv_paths = {
     // clang-format off
     "../tests/cbuffer_unused/cbuffer_unused_001.spv",
     "../tests/glsl/built_in_format.spv",
@@ -804,9 +840,9 @@ const std::vector<const char *> all_spirv_paths = {
     "../tests/raytrace/raytracing.nv.miss.spv",
     "../tests/raytrace/raytracing.nv.raygen.spv",
     "../tests/spirv15/VertexShader.spv",
-     // clang-format on
+    // clang-format on
 };
-} // namespace
+}  // namespace
 INSTANTIATE_TEST_CASE_P(ForAllShaders, SpirvReflectTest,
                         ::testing::ValuesIn(all_spirv_paths));
 
@@ -818,7 +854,7 @@ TEST(SpirvReflectTestCase, TestComputeLocalSize) {
   std::streampos spirv_file_nbytes = spirv_file.tellg();
   spirv_file.seekg(0);
   spirv_.resize(spirv_file_nbytes);
-  spirv_file.read(reinterpret_cast<char *>(spirv_.data()), spirv_.size());
+  spirv_file.read(reinterpret_cast<char*>(spirv_.data()), spirv_.size());
 
   SpvReflectResult result =
       spvReflectCreateShaderModule(spirv_.size(), spirv_.data(), &module_);
@@ -826,7 +862,8 @@ TEST(SpirvReflectTestCase, TestComputeLocalSize) {
       << "spvReflectCreateShaderModule() failed";
 
   ASSERT_EQ(module_.entry_point_count, 1);
-  ASSERT_EQ(module_.entry_points[0].shader_stage, SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT);
+  ASSERT_EQ(module_.entry_points[0].shader_stage,
+            SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT);
   ASSERT_EQ(module_.entry_points[0].local_size.x, 1);
   ASSERT_EQ(module_.entry_points[0].local_size.y, 1);
   ASSERT_EQ(module_.entry_points[0].local_size.z, 1);
@@ -837,12 +874,13 @@ TEST(SpirvReflectTestCase, TestComputeLocalSize) {
 TEST(SpirvReflectTestCase, TestGeometryInvocationsOutputVertices) {
   std::vector<uint8_t> spirv_;
   SpvReflectShaderModule module_;
-  const std::string spirv_path = "../tests/entry_exec_mode/geom_inv_out_vert.spv";
+  const std::string spirv_path =
+      "../tests/entry_exec_mode/geom_inv_out_vert.spv";
   std::ifstream spirv_file(spirv_path, std::ios::binary | std::ios::ate);
   std::streampos spirv_file_nbytes = spirv_file.tellg();
   spirv_file.seekg(0);
   spirv_.resize(spirv_file_nbytes);
-  spirv_file.read(reinterpret_cast<char *>(spirv_.data()), spirv_.size());
+  spirv_file.read(reinterpret_cast<char*>(spirv_.data()), spirv_.size());
 
   SpvReflectResult result =
       spvReflectCreateShaderModule(spirv_.size(), spirv_.data(), &module_);
@@ -850,7 +888,8 @@ TEST(SpirvReflectTestCase, TestGeometryInvocationsOutputVertices) {
       << "spvReflectCreateShaderModule() failed";
 
   ASSERT_EQ(module_.entry_point_count, 1);
-  ASSERT_EQ(module_.entry_points[0].shader_stage, SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT);
+  ASSERT_EQ(module_.entry_points[0].shader_stage,
+            SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT);
   ASSERT_EQ(module_.entry_points[0].invocations, 2);
   ASSERT_EQ(module_.entry_points[0].output_vertices, 2);
 
@@ -858,15 +897,16 @@ TEST(SpirvReflectTestCase, TestGeometryInvocationsOutputVertices) {
 }
 
 class SpirvReflectMultiEntryPointTest : public ::testing::TestWithParam<int> {
-protected:
+ protected:
   void SetUp() override {
     // called after constructor before each test
-    const std::string spirv_path = "../tests/multi_entrypoint/multi_entrypoint.spv";
+    const std::string spirv_path =
+        "../tests/multi_entrypoint/multi_entrypoint.spv";
     std::ifstream spirv_file(spirv_path, std::ios::binary | std::ios::ate);
     std::streampos spirv_file_nbytes = spirv_file.tellg();
     spirv_file.seekg(0);
     spirv_.resize(spirv_file_nbytes);
-    spirv_file.read(reinterpret_cast<char *>(spirv_.data()), spirv_.size());
+    spirv_file.read(reinterpret_cast<char*>(spirv_.data()), spirv_.size());
 
     SpvReflectResult result =
         spvReflectCreateShaderModule(spirv_.size(), spirv_.data(), &module_);
@@ -890,39 +930,29 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetEntryPoint) {
             spvReflectGetEntryPoint(&module_, eps_[0]));
   ASSERT_EQ(&module_.entry_points[1],
             spvReflectGetEntryPoint(&module_, eps_[1]));
-  ASSERT_EQ(NULL,
-            spvReflectGetEntryPoint(&module_, "entry_tess"));
+  ASSERT_EQ(NULL, spvReflectGetEntryPoint(&module_, "entry_tess"));
 }
 
 TEST_F(SpirvReflectMultiEntryPointTest, GetDescriptorBindings0) {
   uint32_t binding_count = 0;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[0],
-                &binding_count,
-                NULL));
+                &module_, eps_[0], &binding_count, NULL));
   ASSERT_EQ(binding_count, 1);
   SpvReflectDescriptorBinding* binding;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[0],
-                &binding_count,
-                &binding));
+                &module_, eps_[0], &binding_count, &binding));
   ASSERT_EQ(binding->set, 0);
   ASSERT_EQ(binding->binding, 1);
   ASSERT_EQ(strcmp(binding->name, "ubo"), 0);
-  ASSERT_EQ(binding->descriptor_type, SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+  ASSERT_EQ(binding->descriptor_type,
+            SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
   SpvReflectResult result;
   ASSERT_EQ(binding,
             spvReflectGetEntryPointDescriptorBinding(
-                &module_,
-                eps_[0],
-                binding->binding,
-                binding->set,
-                &result));
+                &module_, eps_[0], binding->binding, binding->set, &result));
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
 }
 
@@ -930,37 +960,29 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetDescriptorBindings1) {
   uint32_t binding_count = 0;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[1],
-                &binding_count,
-                NULL));
+                &module_, eps_[1], &binding_count, NULL));
   ASSERT_EQ(binding_count, 2);
   SpvReflectDescriptorBinding* bindings[2];
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[1],
-                &binding_count,
-                bindings));
+                &module_, eps_[1], &binding_count, bindings));
   ASSERT_EQ(bindings[0]->set, 0);
   ASSERT_EQ(bindings[0]->binding, 0);
   ASSERT_EQ(strcmp(bindings[0]->name, "tex"), 0);
-  ASSERT_EQ(bindings[0]->descriptor_type, SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
+  ASSERT_EQ(bindings[0]->descriptor_type,
+            SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
 
   ASSERT_EQ(bindings[1]->set, 0);
   ASSERT_EQ(bindings[1]->binding, 1);
   ASSERT_EQ(strcmp(bindings[1]->name, "ubo"), 0);
-  ASSERT_EQ(bindings[1]->descriptor_type, SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+  ASSERT_EQ(bindings[1]->descriptor_type,
+            SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
   for (size_t i = 0; i < 2; ++i) {
     SpvReflectResult result;
-    ASSERT_EQ(bindings[i],
-              spvReflectGetEntryPointDescriptorBinding(
-                  &module_,
-                  eps_[1],
-                  bindings[i]->binding,
-                  bindings[i]->set,
-                  &result));
+    ASSERT_EQ(bindings[i], spvReflectGetEntryPointDescriptorBinding(
+                               &module_, eps_[1], bindings[i]->binding,
+                               bindings[i]->set, &result));
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   }
 }
@@ -973,76 +995,50 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetDescriptorBindingsShared) {
   SpvReflectDescriptorBinding* frag_binding[2];
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[0],
-                &vert_count,
-                &vert_binding));
+                &module_, eps_[0], &vert_count, &vert_binding));
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
             spvReflectEnumerateEntryPointDescriptorBindings(
-                &module_,
-                eps_[1],
-                &frag_count,
-                frag_binding));
+                &module_, eps_[1], &frag_count, frag_binding));
   ASSERT_EQ(vert_binding, frag_binding[1]);
 }
 
 TEST_F(SpirvReflectMultiEntryPointTest, GetDescriptorSets0) {
   uint32_t set_count;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectEnumerateEntryPointDescriptorSets(
-                &module_,
-                eps_[0],
-                &set_count,
-                NULL));
+            spvReflectEnumerateEntryPointDescriptorSets(&module_, eps_[0],
+                                                        &set_count, NULL));
   ASSERT_EQ(set_count, 1);
-  SpvReflectDescriptorSet *set;
+  SpvReflectDescriptorSet* set;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectEnumerateEntryPointDescriptorSets(
-                &module_,
-                eps_[0],
-                &set_count,
-                &set));
+            spvReflectEnumerateEntryPointDescriptorSets(&module_, eps_[0],
+                                                        &set_count, &set));
   ASSERT_EQ(set->set, 0);
   ASSERT_EQ(set->binding_count, 1);
   ASSERT_EQ(set, &module_.entry_points[0].descriptor_sets[0]);
 
   SpvReflectResult result;
-  ASSERT_EQ(set,
-            spvReflectGetEntryPointDescriptorSet(
-                &module_,
-                eps_[0],
-                set->set,
-                &result));
+  ASSERT_EQ(set, spvReflectGetEntryPointDescriptorSet(&module_, eps_[0],
+                                                      set->set, &result));
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
 }
 
 TEST_F(SpirvReflectMultiEntryPointTest, GetDescriptorSets1) {
   uint32_t set_count;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectEnumerateEntryPointDescriptorSets(
-                &module_,
-                eps_[1],
-                &set_count,
-                NULL));
+            spvReflectEnumerateEntryPointDescriptorSets(&module_, eps_[1],
+                                                        &set_count, NULL));
   ASSERT_EQ(set_count, 1);
-  SpvReflectDescriptorSet *set;
+  SpvReflectDescriptorSet* set;
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectEnumerateEntryPointDescriptorSets(
-                &module_,
-                eps_[1],
-                &set_count,
-                &set));
+            spvReflectEnumerateEntryPointDescriptorSets(&module_, eps_[1],
+                                                        &set_count, &set));
   ASSERT_EQ(set->set, 0);
   ASSERT_EQ(set->binding_count, 2);
   ASSERT_EQ(set, &module_.entry_points[1].descriptor_sets[0]);
 
   SpvReflectResult result;
-  ASSERT_EQ(set,
-            spvReflectGetEntryPointDescriptorSet(
-                &module_,
-                eps_[1],
-                set->set,
-                &result));
+  ASSERT_EQ(set, spvReflectGetEntryPointDescriptorSet(&module_, eps_[1],
+                                                      set->set, &result));
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
 }
 
@@ -1052,21 +1048,15 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetInputVariables) {
   for (size_t i = 0; i < 2; ++i) {
     uint32_t count = 0;
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointInputVariables(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  NULL));
+              spvReflectEnumerateEntryPointInputVariables(&module_, eps_[i],
+                                                          &count, NULL));
     ASSERT_EQ(count, counts[i]);
 
     // 2 is the max count
     SpvReflectInterfaceVariable* vars[2];
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointInputVariables(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  vars));
+              spvReflectEnumerateEntryPointInputVariables(&module_, eps_[i],
+                                                          &count, vars));
     for (size_t j = 0; j < counts[i]; ++j) {
       if (vars[j]->decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) {
         // built-ins don't have reasonable locations
@@ -1075,10 +1065,7 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetInputVariables) {
       SpvReflectResult result;
       const SpvReflectInterfaceVariable* var =
           spvReflectGetEntryPointInputVariableByLocation(
-              &module_,
-              eps_[i],
-              vars[j]->location,
-              &result);
+              &module_, eps_[i], vars[j]->location, &result);
       ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
       ASSERT_EQ(var, vars[j]);
       ASSERT_EQ(strcmp(var->name, names[i][var->location]), 0);
@@ -1094,21 +1081,15 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetOutputVariables) {
   for (size_t i = 0; i < 2; ++i) {
     uint32_t count = 0;
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointOutputVariables(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  NULL));
+              spvReflectEnumerateEntryPointOutputVariables(&module_, eps_[i],
+                                                           &count, NULL));
     ASSERT_EQ(count, counts[i]);
 
     // 2 is the max count
     SpvReflectInterfaceVariable* vars[2];
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointOutputVariables(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  vars));
+              spvReflectEnumerateEntryPointOutputVariables(&module_, eps_[i],
+                                                           &count, vars));
     for (size_t j = 0; j < counts[i]; ++j) {
       if (vars[j]->decoration_flags & SPV_REFLECT_DECORATION_BUILT_IN) {
         // built-ins don't have reasonable locations
@@ -1117,10 +1098,7 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetOutputVariables) {
       SpvReflectResult result;
       const SpvReflectInterfaceVariable* var =
           spvReflectGetEntryPointOutputVariableByLocation(
-              &module_,
-              eps_[i],
-              vars[j]->location,
-              &result);
+              &module_, eps_[i], vars[j]->location, &result);
       ASSERT_EQ(result, SPV_REFLECT_RESULT_SUCCESS);
       ASSERT_EQ(var, vars[j]);
       ASSERT_EQ(strcmp(var->name, names[i][var->location]), 0);
@@ -1133,64 +1111,39 @@ TEST_F(SpirvReflectMultiEntryPointTest, GetPushConstants) {
     SpvReflectBlockVariable* var;
     uint32_t count = 0;
     ASSERT_EQ(SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH,
-              spvReflectEnumerateEntryPointPushConstantBlocks(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  &var));
+              spvReflectEnumerateEntryPointPushConstantBlocks(&module_, eps_[i],
+                                                              &count, &var));
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointPushConstantBlocks(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  NULL));
+              spvReflectEnumerateEntryPointPushConstantBlocks(&module_, eps_[i],
+                                                              &count, NULL));
     ASSERT_EQ(count, 1);
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-              spvReflectEnumerateEntryPointPushConstantBlocks(
-                  &module_,
-                  eps_[i],
-                  &count,
-                  &var));
+              spvReflectEnumerateEntryPointPushConstantBlocks(&module_, eps_[i],
+                                                              &count, &var));
     SpvReflectResult result;
-    ASSERT_EQ(var,
-              spvReflectGetEntryPointPushConstantBlock(
-                  &module_,
-                  eps_[i],
-                  &result));
+    ASSERT_EQ(var, spvReflectGetEntryPointPushConstantBlock(&module_, eps_[i],
+                                                            &result));
     ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   }
 }
 
 TEST_F(SpirvReflectMultiEntryPointTest, ChangeDescriptorBindingNumber) {
-  const SpvReflectDescriptorBinding* binding = spvReflectGetEntryPointDescriptorBinding(
-      &module_,
-      eps_[0],
-      1,
-      0,
-      NULL);
+  const SpvReflectDescriptorBinding* binding =
+      spvReflectGetEntryPointDescriptorBinding(&module_, eps_[0], 1, 0, NULL);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectChangeDescriptorBindingNumbers(&module_,
-                                                     binding,
-                                                     2,
-                                                     1));
+            spvReflectChangeDescriptorBindingNumbers(&module_, binding, 2, 1));
   // Change descriptor binding numbers doesn't currently resort so it won't
   // invalidate binding, but if that changes this test will need to be fixed.
   ASSERT_EQ(binding->set, 1);
   ASSERT_EQ(binding->binding, 2);
 
   SpvReflectResult result;
-  const SpvReflectDescriptorSet* set0 = spvReflectGetEntryPointDescriptorSet(
-      &module_,
-      eps_[0],
-      1,
-      &result);
+  const SpvReflectDescriptorSet* set0 =
+      spvReflectGetEntryPointDescriptorSet(&module_, eps_[0], 1, &result);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   ASSERT_EQ(set0->binding_count, 1);
-  const SpvReflectDescriptorSet* set1 = spvReflectGetEntryPointDescriptorSet(
-      &module_,
-      eps_[1],
-      1,
-      &result);
+  const SpvReflectDescriptorSet* set1 =
+      spvReflectGetEntryPointDescriptorSet(&module_, eps_[1], 1, &result);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   ASSERT_EQ(set1->binding_count, 1);
 
@@ -1198,31 +1151,21 @@ TEST_F(SpirvReflectMultiEntryPointTest, ChangeDescriptorBindingNumber) {
 }
 
 TEST_F(SpirvReflectMultiEntryPointTest, ChangeDescriptorSetNumber) {
-  const SpvReflectDescriptorSet* set = spvReflectGetDescriptorSet(
-      &module_,
-      0,
-      NULL);
+  const SpvReflectDescriptorSet* set =
+      spvReflectGetDescriptorSet(&module_, 0, NULL);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS,
-            spvReflectChangeDescriptorSetNumber(&module_,
-                                                set,
-                                                1));
+            spvReflectChangeDescriptorSetNumber(&module_, set, 1));
   // Change descriptor binding numbers doesn't currently resort so it won't
   // invalidate binding, but if that changes this test will need to be fixed.
   ASSERT_EQ(set->set, 1);
 
   SpvReflectResult result;
-  const SpvReflectDescriptorSet* set0 = spvReflectGetEntryPointDescriptorSet(
-      &module_,
-      eps_[0],
-      1,
-      &result);
+  const SpvReflectDescriptorSet* set0 =
+      spvReflectGetEntryPointDescriptorSet(&module_, eps_[0], 1, &result);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   ASSERT_EQ(set0->binding_count, 1);
-  const SpvReflectDescriptorSet* set1 = spvReflectGetEntryPointDescriptorSet(
-      &module_,
-      eps_[1],
-      1,
-      &result);
+  const SpvReflectDescriptorSet* set1 =
+      spvReflectGetEntryPointDescriptorSet(&module_, eps_[1], 1, &result);
   ASSERT_EQ(SPV_REFLECT_RESULT_SUCCESS, result);
   ASSERT_EQ(set1->binding_count, 2);
 

--- a/util/stripper/stripper.cpp
+++ b/util/stripper/stripper.cpp
@@ -20,14 +20,12 @@ int SpvStripReflect(uint32_t* data, size_t len) {
   const uint32_t kUserTypeGOOGLEDecoration = 5636;
 
   // Make sure we at least have a header and the magic number is correct
-  if (!data || len < kHeaderLength || data[0] != kMagicNumber)
-    return -1;
+  if (!data || len < kHeaderLength || data[0] != kMagicNumber) return -1;
 
   std::vector<uint32_t> spirv;
   spirv.reserve(len);
 
-  for (uint32_t i = 0; i < kHeaderLength; ++i)
-    spirv.push_back(data[i]);
+  for (uint32_t i = 0; i < kHeaderLength; ++i) spirv.push_back(data[i]);
 
   for (uint32_t pos = kHeaderLength; pos < len;) {
     const uint32_t inst_len = (data[pos] >> 16);
@@ -36,23 +34,19 @@ int SpvStripReflect(uint32_t* data, size_t len) {
     bool skip = false;
     if (opcode == kDecorateStringOpcode ||
         opcode == kMemberDecorateStringOpcode ||
-        opcode == kSourceContinuedOpcode ||
-        opcode == kSourceOpcode ||
-        opcode == kStringOpcode ||
-        opcode == kLineOpcode ||
+        opcode == kSourceContinuedOpcode || opcode == kSourceOpcode ||
+        opcode == kStringOpcode || opcode == kLineOpcode ||
         opcode == kModuleProcessedOpcode) {
       skip = true;
     } else if (opcode == kDecorateIdOpcode) {
-      if (pos + 2 >= len)
-        return -1;
+      if (pos + 2 >= len) return -1;
       if (data[pos + 2] == kCounterBufferDecoration ||
           data[pos + 2] == kUserTypeGOOGLEDecoration) {
         skip = true;
       }
     } else if (opcode == kExtensionOpcode) {
-      if (pos + 1 >= len)
-        return -1;
-      const char *ext_name = reinterpret_cast<const char *>(&data[pos + 1]);
+      if (pos + 1 >= len) return -1;
+      const char* ext_name = reinterpret_cast<const char*>(&data[pos + 1]);
       if (0 == std::strcmp(ext_name, "SPV_GOOGLE_decorate_string") ||
           0 == std::strcmp(ext_name, "SPV_GOOGLE_hlsl_functionality1") ||
           0 == std::strcmp(ext_name, "SPV_GOOGLE_user_type"))
@@ -60,13 +54,11 @@ int SpvStripReflect(uint32_t* data, size_t len) {
     }
 
     if (!skip)
-      for (uint32_t i = 0; i < inst_len; ++i)
-        spirv.push_back(data[pos + i]);
+      for (uint32_t i = 0; i < inst_len; ++i) spirv.push_back(data[pos + i]);
     pos += inst_len;
   }
 
-  for (uint32_t i = 0; i < spirv.size(); ++i)
-    data[i] = spirv[i];
+  for (uint32_t i = 0; i < spirv.size(); ++i) data[i] = spirv[i];
 
   return static_cast<int>(spirv.size());
 }


### PR DESCRIPTION
This is just a suggestion, but SPIRV-Tools has a .clang-format and it might be nice to use the same formatting (and eventually maybe enforce it on PRs).