### PR TITLE
Adding word offset to SpvReflectBlockVariable

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2272,6 +2272,7 @@ static SpvReflectResult ParseDescriptorBlockVariable(
         ApplyArrayTraits(p_member_type, &p_member_var->array);
       }
 
+      p_member_var->word_offset.offset = p_type_node->member_decorations[member_index].offset.word_offset;
       p_member_var->type_description = p_member_type;
     }
   }

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -379,6 +379,11 @@ typedef struct SpvReflectBlockVariable {
   struct SpvReflectBlockVariable*   members;
 
   SpvReflectTypeDescription*        type_description;
+
+  struct {
+    uint32_t                          offset;
+  } word_offset;
+
 } SpvReflectBlockVariable;
 
 /*! @struct SpvReflectDescriptorBinding


### PR DESCRIPTION
This change adds the word offset, of UBO offsets to the `SpvReflectBlockVariable` struct as part of #158.

I kept it in the `word_offset` struct, simply because you said you didn't have a strong opinion, but I can of course pop it out. 