### PR TITLE
Zero init fix

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -3718,7 +3718,11 @@ static SpvReflectResult CreateShaderModule(
     memcpy(p_module->_internal->spirv_code, p_code, size);
   }
 
-  SpvReflectPrvParser parser = { 0 };
+  // Initialize everything to zero
+  SpvReflectPrvParser parser = {};
+  memset(&parser, 0, sizeof(SpvReflectPrvParser));
+
+  // Create parser
   SpvReflectResult result = CreateParser(p_module->_internal->spirv_size,
                                          p_module->_internal->spirv_code,
                                          &parser);

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -3719,7 +3719,7 @@ static SpvReflectResult CreateShaderModule(
   }
 
   // Initialize everything to zero
-  SpvReflectPrvParser parser = {};
+  SpvReflectPrvParser parser;
   memset(&parser, 0, sizeof(SpvReflectPrvParser));
 
   // Create parser


### PR DESCRIPTION
Changed (incorrect) brace initalizer zero init to use `memset`. Brace initializer was behaving different depending on platform and would sometimes throw a warning with GCC.

This address issue #172.