### PR TITLE
Workaround for bazel bug and windows-latest runners

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -10,7 +10,8 @@ jobs:
     name: Build and run tests using Bazel
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Workaround for https://github.com/actions/runner-images/issues/7675. 
+        os: [ubuntu-latest, macos-latest, windows-2019]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
There is a bazel bug that is affecting the windows-latest runners for github workflows.  More details at https://github.com/actions/runner-images/issues/7675 and https://github.com/bazelbuild/bazel/issues/18592