### PR TITLE
Added support for specialization constants. They are now automaticall…

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -2201,6 +2201,19 @@ void SpvReflectToYaml::Write(std::ostream& os) {
        << SafeString(sm_.push_constant_blocks[i].name) << std::endl;
   }
 
+  // uint32_t                            specialization_constant_count;
+  os << t1 << "specialization_constant_count: " << sm_.specialization_constant_count << ",\n";
+  // SpvReflectSpecializationConstant*   specialization_constants;
+  os << t1 << "specialization_constants:" << std::endl;
+  for (uint32_t i = 0; i < sm_.specialization_constant_count; ++i) {
+    os << t2 << "- *sc" << i << " # " << SafeString(sm_.specialization_constants[i].name) << std::endl;
+    os << t3 << "spirv_id: " << sm_.specialization_constants[i].spirv_id << std::endl;
+    os << t3 << "constant_id: " << sm_.specialization_constants[i].constant_id << std::endl;
+    os << t3 << "size: " << sm_.specialization_constants[i].size << std::endl;
+    os << t3 << "default_value (as float): " << sm_.specialization_constants[i].default_value.float_value << std::endl;
+    os << t3 << "default_value (as int): " << sm_.specialization_constants[i].default_value.int_bool_value << std::endl;
+  }
+
   if (verbosity_ >= 2) {
     // struct Internal {
     os << t1 << "_internal:" << std::endl;


### PR DESCRIPTION
As commit name states, I added support for specialization constants. All the code written follows the already-established style of the [SPIRV-Reflect](https://github.com/KhronosGroup/SPIRV-Reflect) codebase, and I have provided all the needed functions/fields, that such a feature would make sense to have.

Additions:

1. Two new fields within `SpvReflectShaderModule`:
    - `uint32_t specialization_constant_count;`
    - `SpvReflectSpecializationConstant* specialization_constants;`
    
    As you can see, a new type `SpvReflectSpecializationConstant` has also been added. It includes the following members:
    - `const char* name;`
    - `uint32_t spirv_id;`
    - `uint32_t constant_id;`
    - `uint32_t size;`
    - `SpvReflectSpecializationConstantType constant_type;` where all possible types are:
        - `SPV_REFLECT_SPECIALIZATION_CONSTANT_BOOL`
        - `SPV_REFLECT_SPECIALIZATION_CONSTANT_INT`
        - `SPV_REFLECT_SPECIALIZATION_CONSTANT_FLOAT`
    - `union { float float_value; uint32_t uint_bool_value } default_value;`

   These fields can freely be accessed in `SpvReflectShaderModule`, just as all other types (`push_constant_blocks`, `descriptor_bindings`, etc.) are.
   
2. Two new enumerating methods:
    - `spvReflectEnumerateSpecializationConstants(p_module, p_count, pp_constants)` - a static method in `spirv-reflect.h`, which works like any other `spvReflectEnumerate...` method.
    
    - `ShaderModule::EnumerateSpecializationConstants(p_count, pp_constants)` - a public member method of the `ShaderModule` class. Just like the rest of `ShaderModule`'s member enumerating functions, it relies on its static counterpart in `spirv-reflect.h` under the hood (in this case - `spvReflectEnumerateSpecializationConstants()`).

3. Last but not least, `SpvReflectToYaml` (aka the `yamlizer`) also picks up specialization constants and displays them same way all other members are shown. Example:

<pre><code>specialization_constant_count: 3, 
specialization_constants:
    - *sc0 # "ENABLE_SHADOWS"
      spirv_id: 443
      constant_id: 0
      size: 4
      default_value (as float): 1.4013e-45
      default_value (as int): 1
      ...
</code></pre>

4. There are a few other new internal functions (for example for parsing the specialization constants), but they, obviously, will not be available to the user.

Note that all the new additions are properly documented, once again, following the general styling of [SPIRV-Reflect](https://github.com/KhronosGroup/SPIRV-Reflect)'s documentation within the code.