### PR TITLE
Fix finding function parameter baseID of OpAccessChain

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -564,9 +564,22 @@ static uint32_t FindBaseId(SpvReflectPrvParser* p_parser,
   uint32_t base_id = ac->base_id;
   SpvReflectPrvNode* base_node = FindNode(p_parser, base_id);
   while (base_node->op != SpvOpVariable) {
-    assert(base_node->op == SpvOpLoad);
-    UNCHECKED_READU32(p_parser, base_node->word_offset + 3, base_id);
-    SpvReflectPrvAccessChain* base_ac = FindAccessChain(p_parser, base_id);
+	switch (base_node->op) {
+	  case SpvOpLoad: {
+		UNCHECKED_READU32(p_parser, base_node->word_offset + 3, base_id);
+	  }
+	  break;
+	  case SpvOpFunctionParameter: {
+		UNCHECKED_READU32(p_parser, base_node->word_offset + 2, base_id);
+	  }
+	  break;
+	  default: {
+	    assert(false);
+	  }
+	  break;
+	}
+
+	SpvReflectPrvAccessChain* base_ac = FindAccessChain(p_parser, base_id);
     if (base_ac == 0) {
       return 0;
     }
@@ -1004,6 +1017,11 @@ static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser)
         function_node = (uint32_t)INVALID_VALUE;
       }
       break;
+	  case SpvOpFunctionParameter:
+	  {
+		CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+	  }
+	  break;
     }
 
     if (p_node->is_type) {


### PR DESCRIPTION
This PR adds a fix to parsing push constant blocks whenever the code contains an `OpAccessChain` instruction with a baseID referencing an `OpFunctionParameter` instruction, as those were not handled at all.
For example, in this GLSL shader:
```glsl
#version 460

layout (push_constant) uniform PushConstants {
	float baz;
} constants;

// Keep the function from being marked unused
layout (location = 0) in vec2 valueA;
layout (location = 0) out float valueOut;

float foo(vec2 v) {
	return v.x;
}

void main() {
	valueOut = foo(valueA);
}
```