### PR TITLE
Use Enum instead of magic value for Array Dim

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1810,7 +1810,8 @@ static SpvReflectResult ParseType(
             uint32_t dim_index = p_type->traits.array.dims_count;
             if (p_length_node->op == SpvOpSpecConstant ||
                 p_length_node->op == SpvOpSpecConstantOp) {
-              p_type->traits.array.dims[dim_index] = 0xFFFFFFFF;
+              p_type->traits.array.dims[dim_index] =
+                  (uint32_t)SPV_REFLECT_ARRAY_DIM_SPEC_CONSTANT;
               p_type->traits.array.spec_constant_op_ids[dim_index] = length_id;
               p_type->traits.array.dims_count += 1;
             } else {
@@ -1819,7 +1820,8 @@ static SpvReflectResult ParseType(
               if (result == SPV_REFLECT_RESULT_SUCCESS) {
                 // Write the array dim and increment the count and offset
                 p_type->traits.array.dims[dim_index] = length;
-                p_type->traits.array.spec_constant_op_ids[dim_index] = 0xFFFFFFFF;
+                p_type->traits.array.spec_constant_op_ids[dim_index] =
+                    (uint32_t)SPV_REFLECT_ARRAY_DIM_SPEC_CONSTANT;
                 p_type->traits.array.dims_count += 1;
               } else {
                 result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
@@ -1846,7 +1848,8 @@ static SpvReflectResult ParseType(
         IF_READU32(result, p_parser, p_node->word_offset + 2, element_type_id);
         p_type->traits.array.stride = p_node->decorations.array_stride;
         uint32_t dim_index = p_type->traits.array.dims_count;
-        p_type->traits.array.dims[dim_index] = 0;
+        p_type->traits.array.dims[dim_index] =
+            (uint32_t)SPV_REFLECT_ARRAY_DIM_RUNTIME;
         p_type->traits.array.spec_constant_op_ids[dim_index] = 0;
         p_type->traits.array.dims_count += 1;
         // Parse next dimension or element type

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -307,10 +307,17 @@ typedef struct SpvReflectImageTraits {
   SpvImageFormat                    image_format;
 } SpvReflectImageTraits;
 
+typedef enum SpvReflectArrayDimType {
+  SPV_REFLECT_ARRAY_DIM_RUNTIME       = 0,         // OpTypeRuntimeArray
+  SPV_REFLECT_ARRAY_DIM_SPEC_CONSTANT = 0xFFFFFFFF // specialization constant
+} SpvReflectArrayDimType;
+
 typedef struct SpvReflectArrayTraits {
   uint32_t                          dims_count;
-  // Each entry is: 0xFFFFFFFF for a specialization constant dimension,
-  // 0 for a runtime array dimension, and the array length otherwise.
+  // Each entry is either:
+  // - specialization constant dimension
+  // - OpTypeRuntimeArray
+  // - the array length otherwise
   uint32_t                          dims[SPV_REFLECT_MAX_ARRAY_DIMS];
   // Stores Ids for dimensions that are specialization constants
   uint32_t                          spec_constant_op_ids[SPV_REFLECT_MAX_ARRAY_DIMS];
@@ -340,6 +347,7 @@ typedef struct SpvReflectTypeDescription {
     SpvReflectArrayTraits           array;
   } traits;
 
+  // if 'op' is OpTypeStruct, list members
   uint32_t                          member_count;
   struct SpvReflectTypeDescription* members;
 } SpvReflectTypeDescription;


### PR DESCRIPTION
Was my issue in https://github.com/KhronosGroup/SPIRV-Reflect/issues/177 but having an Enum is nicer then just thinking there was a bug that it was set to `0`