### PR TITLE
Add default case to switch

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -110,7 +110,7 @@ std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang) {
     case SpvSourceLanguageNZSL:
       return "NZSL";
 
-    case SpvSourceLanguageMax:
+    default:
       break;
   }
   // unhandled SpvSourceLanguage enum value

--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -89,8 +89,6 @@ std::string ToStringGenerator(SpvReflectGenerator generator) {
 
 std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang) {
   switch (lang) {
-    case SpvSourceLanguageUnknown:
-      return "Unknown";
     case SpvSourceLanguageESSL:
       return "ESSL";
     case SpvSourceLanguageGLSL:
@@ -113,8 +111,9 @@ std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang) {
     default:
       break;
   }
-  // unhandled SpvSourceLanguage enum value
-  return "???";
+  // SpvSourceLanguageUnknown, SpvSourceLanguageMax, or another value that does
+  // not correspond to a known language.
+  return "Unknown";
 }
 
 std::string ToStringSpvExecutionModel(SpvExecutionModel model) {

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -5327,7 +5327,7 @@ const char* spvReflectSourceLanguage(SpvSourceLanguage source_lang)
     case SpvSourceLanguageSYCL           : return "SYCL";
     case SpvSourceLanguageHERO_C         : return "Hero C";
     case SpvSourceLanguageNZSL           : return "NZSL";
-    case SpvSourceLanguageMax:
+    default:
       break;
   }
   return "";

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -5317,7 +5317,6 @@ SpvReflectResult spvReflectChangeOutputVariableLocation(
 const char* spvReflectSourceLanguage(SpvSourceLanguage source_lang)
 {
   switch (source_lang) {
-    case SpvSourceLanguageUnknown        : return "Unknown";
     case SpvSourceLanguageESSL           : return "ESSL";
     case SpvSourceLanguageGLSL           : return "GLSL";
     case SpvSourceLanguageOpenCL_C       : return "OpenCL_C";
@@ -5330,7 +5329,9 @@ const char* spvReflectSourceLanguage(SpvSourceLanguage source_lang)
     default:
       break;
   }
-  return "";
+  // The source language is SpvSourceLanguageUnknown, SpvSourceLanguageMax, or
+  // some other value that does not correspond to a knonwn language.
+  return "Unknown";
 }
 
 const char* spvReflectBlockVariableTypeName(

--- a/tests/test-spirv-reflect.cpp
+++ b/tests/test-spirv-reflect.cpp
@@ -67,10 +67,10 @@ TEST(SpirvReflectTestCase, SourceLanguage) {
 
   EXPECT_STREQ(spvReflectSourceLanguage(SpvSourceLanguageUnknown), "Unknown");
   // Invalid inputs
-  EXPECT_STREQ(spvReflectSourceLanguage(SpvSourceLanguageMax), "");
+  EXPECT_STREQ(spvReflectSourceLanguage(SpvSourceLanguageMax), "Unknown");
   EXPECT_STREQ(spvReflectSourceLanguage(
                    static_cast<SpvSourceLanguage>(SpvSourceLanguageMax - 1)),
-               "");
+               "Unknown");
 }
 
 class SpirvReflectTest : public ::testing::TestWithParam<const char*> {


### PR DESCRIPTION
When new source languages are added to spirv-headers, spirv-refelct will
not compile because not every possible case is handled by the switch.

I changed the `SpvSourceLanguageMax` case to be a default case. This
will make sure that spirv-refect can build with new version of
spirv-headers.
