### PR TITLE
Fixed localSizeId always reading from x_node

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -3565,7 +3565,7 @@ static SpvReflectResult ParseExecutionModes(
               p_entry_point->local_size.y =
                   (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
             } else {
-              CHECKED_READU32(p_parser, x_node->word_offset + 3,
+              CHECKED_READU32(p_parser, y_node->word_offset + 3,
                               p_entry_point->local_size.y);
             }
 
@@ -3573,7 +3573,7 @@ static SpvReflectResult ParseExecutionModes(
               p_entry_point->local_size.z =
                   (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
             } else {
-              CHECKED_READU32(p_parser, x_node->word_offset + 3,
+              CHECKED_READU32(p_parser, z_node->word_offset + 3,
                               p_entry_point->local_size.z);
             }
           }


### PR DESCRIPTION
SpvExecutionModeLocalSizeId case was writing to the entry point's localSize, 
by reading **only from the x_node into x, y, z fields**.

Its a slight typo that happened in [these commits](https://github.com/KhronosGroup/SPIRV-Reflect/pull/210/commits)