### PR TITLE
Add Address Sanitization to CI build

### DIFF
--- a/.github/workflows/linux-cmake-build.yml
+++ b/.github/workflows/linux-cmake-build.yml
@@ -14,6 +14,10 @@ jobs:
   linux-build:
     name: Build and run tests on Linux using CMake
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        asan: ["ON", "OFF"]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -25,7 +29,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DSPIRV_REFLECT_BUILD_TESTS=ON
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DSPIRV_REFLECT_BUILD_TESTS=ON -DSPIRV_REFLECT_ENABLE_ASAN=${{matrix.asan}}
           make -j $(nproc)
       - name: Run unit tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,13 @@ if (SPIRV_REFLECT_EXECUTABLE)
     if (SPIRV_REFLECT_ENABLE_ASSERTS)
         target_compile_definitions(spirv-reflect PRIVATE SPIRV_REFLECT_ENABLE_ASSERTS)
     endif()
+
     set_target_properties(spirv-reflect PROPERTIES CXX_STANDARD 11)
     target_include_directories(spirv-reflect PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     if(WIN32)
         target_compile_definitions(spirv-reflect PRIVATE _CRT_SECURE_NO_WARNINGS)
     endif()
-    
+
     install(TARGETS spirv-reflect RUNTIME DESTINATION bin)
 
     # ==========================================================================
@@ -68,7 +69,7 @@ if (SPIRV_REFLECT_EXECUTABLE)
     if(WIN32)
         target_compile_definitions(spirv-reflect-pp PRIVATE _CRT_SECURE_NO_WARNINGS)
     endif()
-    
+
     install(TARGETS spirv-reflect-pp RUNTIME DESTINATION bin)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,17 @@ OPTION(SPIRV_REFLECT_STRIPPER       "Build stripper utility" OFF)
 OPTION(SPIRV_REFLECT_STATIC_LIB     "Build a SPIRV-Reflect static library" OFF)
 OPTION(SPIRV_REFLECT_BUILD_TESTS    "Build the SPIRV-Reflect test suite" OFF)
 OPTION(SPIRV_REFLECT_ENABLE_ASSERTS "Enable asserts for debugging" OFF)
+OPTION(SPIRV_REFLECT_ENABLE_ASAN    "Use address sanitization" OFF)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")
+
+if (SPIRV_REFLECT_ENABLE_ASAN)
+    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address)
+endif()
 
 if (SPIRV_REFLECT_EXECUTABLE)
     # ==========================================================================


### PR DESCRIPTION
- First commit just ran `dos2unix` on CMake file
- 2nd commit is adding an option to run with `-fsanitize=address` in CI to catch any potential issues (which currently there are none!)
  - Also run Release version in CI as that is what ends up in the SDK