### PR TITLE
[WIP] Add Access Flags for DescriptorBinding

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -696,6 +696,28 @@ std::string ToStringDecorationFlags(
   return sstream.str();
 }
 
+std::string ToStringAccessFlags(SpvReflectAccessFlags access_flags) {
+  if (access_flags == SPV_REFLECT_ACCESS_NONE) {
+    return "NONE";
+  }
+
+#define PRINT_AND_CLEAR_ACCESS_FLAG(stream, flags, bit)                       \
+  if (((flags) & (SPV_REFLECT_ACCESS_##bit)) == (SPV_REFLECT_ACCESS_##bit)) { \
+    stream << #bit << " ";                                                    \
+    flags ^= SPV_REFLECT_ACCESS_##bit;                                        \
+  }
+  std::stringstream sstream;
+  PRINT_AND_CLEAR_ACCESS_FLAG(sstream, access_flags, READ);
+  PRINT_AND_CLEAR_ACCESS_FLAG(sstream, access_flags, WRITE);
+  PRINT_AND_CLEAR_ACCESS_FLAG(sstream, access_flags, ATOMIC);
+#undef PRINT_AND_CLEAR_ACCESS_FLAG
+  if (access_flags != 0) {
+    // Unhandled SpvReflectAccessFlags bit
+    sstream << "???";
+  }
+  return sstream.str();
+}
+
 std::string ToStringFormat(SpvReflectFormat fmt) {
   switch (fmt) {
     case SPV_REFLECT_FORMAT_UNDEFINED:
@@ -1921,6 +1943,9 @@ void SpvReflectToYaml::WriteDescriptorBinding(
 
   //   uint32_t                            accessed;
   os << t1 << "accessed: " << db.accessed << std::endl;
+  //   SpvReflectAccessFlags               access_flags;
+  os << t1 << "access_flags: " << AsHexString(db.access_flags) << " # "
+     << ToStringAccessFlags(db.access_flags) << std::endl;
 
   //   uint32_t                            uav_counter_id;
   os << t1 << "uav_counter_id: " << db.uav_counter_id << std::endl;

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -178,6 +178,22 @@ typedef struct SpvReflectPrvString {
 // clang-format on
 
 // clang-format off
+// There are a limit set of instructions that can touch an OpVariable,
+// these are represented here with how it was accessed
+// Examples:
+//    OpImageRead  -> OpLoad              -> OpVariable
+//    OpImageWrite -> OpLoad              -> OpVariable
+//    OpStore      -> OpAccessChain       -> OpVariable
+//    OpAtomicIAdd -> OpAccessChain       -> OpVariable
+//    OpAtomicLoad -> OpImageTexelPointer -> OpVariable
+typedef struct SpvReflectPrvAccessedVariable {
+  uint32_t               result_id;
+  uint32_t               variable_ptr;
+  SpvReflectAccessFlags  access_flags;
+} SpvReflectPrvAccessedVariable;
+// clang-format on
+
+// clang-format off
 typedef struct SpvReflectPrvFunction {
   uint32_t                        id;
   uint32_t                        callee_count;
@@ -185,6 +201,8 @@ typedef struct SpvReflectPrvFunction {
   struct SpvReflectPrvFunction**  callee_ptrs;
   uint32_t                        accessed_ptr_count;
   uint32_t*                       accessed_ptrs;
+  uint32_t                        accessed_variable_ptr_count;
+  SpvReflectPrvAccessedVariable*  accessed_variable_ptrs;
 } SpvReflectPrvFunction;
 // clang-format on
 
@@ -685,6 +703,7 @@ static void DestroyParser(SpvReflectPrvParser* p_parser)
       SafeFree(p_parser->functions[i].callees);
       SafeFree(p_parser->functions[i].callee_ptrs);
       SafeFree(p_parser->functions[i].accessed_ptrs);
+      SafeFree(p_parser->functions[i].accessed_variable_ptrs);
     }
 
     // Free access chains
@@ -1160,6 +1179,7 @@ static SpvReflectResult ParseFunction(
   p_func->callee_count = 0;
   p_func->accessed_ptr_count = 0;
 
+  // First get count to know how much to allocate
   for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
     SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op == SpvOpFunctionEnd) {
@@ -1207,10 +1227,17 @@ static SpvReflectResult ParseFunction(
     if (IsNull(p_func->accessed_ptrs)) {
       return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
     }
+
+    p_func->accessed_variable_ptrs = (SpvReflectPrvAccessedVariable*)calloc(
+        p_func->accessed_ptr_count, sizeof(*(p_func->accessed_variable_ptrs)));
+    if (IsNull(p_func->accessed_variable_ptrs)) {
+      return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
   }
 
   p_func->callee_count = 0;
   p_func->accessed_ptr_count = 0;
+  // Now have allocation, fill in values
   for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
     SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
     if (p_node->op == SpvOpFunctionEnd) {
@@ -1221,19 +1248,59 @@ static SpvReflectResult ParseFunction(
         CHECKED_READU32(p_parser, p_node->word_offset + 3,
                         p_func->callees[p_func->callee_count]);
         (++p_func->callee_count);
-      }
-      break;
-      case SpvOpLoad:
+      } break;
       case SpvOpAccessChain:
       case SpvOpInBoundsAccessChain:
       case SpvOpPtrAccessChain:
       case SpvOpArrayLength:
       case SpvOpGenericPtrMemSemantics:
-      case SpvOpInBoundsPtrAccessChain:
+      case SpvOpInBoundsPtrAccessChain: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 3,
+                        p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 3,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .variable_ptr);
+        // Need to track Result ID as not sure there has been any memory access
+        // through here yet
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 2,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .result_id);
+        (++p_func->accessed_ptr_count);
+      } break;
+      case SpvOpLoad: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 3,
+                        p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 3,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .variable_ptr);
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 2,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .result_id);
+        p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+            .access_flags = SPV_REFLECT_ACCESS_READ;
+        (++p_func->accessed_ptr_count);
+      } break;
       case SpvOpImageTexelPointer:
       {
         CHECKED_READU32(p_parser, p_node->word_offset + 3,
                         p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 3,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .variable_ptr);
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 2,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .result_id);
+        p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+            .access_flags = SPV_REFLECT_ACCESS_ATOMIC;
         (++p_func->accessed_ptr_count);
       }
       break;
@@ -1241,6 +1308,13 @@ static SpvReflectResult ParseFunction(
       {
         CHECKED_READU32(p_parser, p_node->word_offset + 2,
                         p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+
+        CHECKED_READU32(
+            p_parser, p_node->word_offset + 2,
+            p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+                .variable_ptr);
+        p_func->accessed_variable_ptrs[p_func->accessed_ptr_count]
+            .access_flags = SPV_REFLECT_ACCESS_WRITE;
         (++p_func->accessed_ptr_count);
       }
       break;
@@ -1259,6 +1333,64 @@ static SpvReflectResult ParseFunction(
     }
   }
 
+  // Apply the SpvReflectAccessFlags to all things touching an OpVariable
+  for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
+    SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+    if (p_node->op == SpvOpFunctionEnd) {
+      break;
+    }
+    // These are memory accesses instruction
+    uint32_t memory_access_ptr = 0;
+    SpvReflectAccessFlags memory_access_type = SPV_REFLECT_ACCESS_NONE;
+    switch (p_node->op) {
+      case SpvOpLoad: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 3, memory_access_ptr);
+        memory_access_type = SPV_REFLECT_ACCESS_READ;
+      } break;
+      case SpvOpImageWrite:
+      case SpvOpStore: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 1, memory_access_ptr);
+        memory_access_type = SPV_REFLECT_ACCESS_WRITE;
+      } break;
+      case SpvOpImageTexelPointer:
+      case SpvOpAtomicLoad:
+      case SpvOpAtomicExchange:
+      case SpvOpAtomicCompareExchange:
+      case SpvOpAtomicIIncrement:
+      case SpvOpAtomicIDecrement:
+      case SpvOpAtomicIAdd:
+      case SpvOpAtomicISub:
+      case SpvOpAtomicSMin:
+      case SpvOpAtomicUMin:
+      case SpvOpAtomicSMax:
+      case SpvOpAtomicUMax:
+      case SpvOpAtomicAnd:
+      case SpvOpAtomicOr:
+      case SpvOpAtomicXor:
+      case SpvOpAtomicFMinEXT:
+      case SpvOpAtomicFMaxEXT:
+      case SpvOpAtomicFAddEXT: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 3, memory_access_ptr);
+        memory_access_type = SPV_REFLECT_ACCESS_ATOMIC;
+      } break;
+      case SpvOpAtomicStore: {
+        CHECKED_READU32(p_parser, p_node->word_offset + 1, memory_access_ptr);
+        memory_access_type = SPV_REFLECT_ACCESS_ATOMIC;
+      } break;
+      default:
+        break;
+    }
+
+    if (memory_access_ptr == 0) {
+      continue;
+    }
+    for (uint32_t k = 0; k < p_func->accessed_ptr_count; k++) {
+      if (p_func->accessed_variable_ptrs[k].result_id == memory_access_ptr) {
+        p_func->accessed_variable_ptrs[k].access_flags |= memory_access_type;
+      }
+    }
+  }
+
   if (p_func->callee_count > 0) {
     qsort(p_func->callees, p_func->callee_count,
           sizeof(*(p_func->callees)), SortCompareUint32);
@@ -1270,6 +1402,7 @@ static SpvReflectResult ParseFunction(
     qsort(p_func->accessed_ptrs, p_func->accessed_ptr_count,
           sizeof(*(p_func->accessed_ptrs)), SortCompareUint32);
   }
+  p_func->accessed_variable_ptr_count = p_func->accessed_ptr_count;
   p_func->accessed_ptr_count = (uint32_t)DedupSortedUint32(p_func->accessed_ptrs,
                                                            p_func->accessed_ptr_count);
 
@@ -3317,6 +3450,7 @@ static SpvReflectResult ParseStaticallyUsedResources(
   called_function_count = DedupSortedUint32(p_called_functions, called_function_count);
 
   uint32_t used_variable_count = 0;
+  uint32_t used_acessed_count = 0;
   for (size_t i = 0, j = 0; i < called_function_count; ++i) {
     // No need to bounds check j because a missing ID issue would have been
     // found during TraverseCallGraph
@@ -3324,8 +3458,10 @@ static SpvReflectResult ParseStaticallyUsedResources(
       ++j;
     }
     used_variable_count += p_parser->functions[j].accessed_ptr_count;
+    used_acessed_count += p_parser->functions[j].accessed_variable_ptr_count;
   }
   uint32_t* used_variables = NULL;
+  SpvReflectPrvAccessedVariable* used_accesses = NULL;
   if (used_variable_count > 0) {
     used_variables = (uint32_t*)calloc(used_variable_count,
                                        sizeof(*used_variables));
@@ -3333,8 +3469,16 @@ static SpvReflectResult ParseStaticallyUsedResources(
       SafeFree(p_called_functions);
       return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
     }
+
+    used_accesses = (SpvReflectPrvAccessedVariable*)calloc(
+        used_acessed_count, sizeof(SpvReflectPrvAccessedVariable));
+    if (IsNull(used_accesses)) {
+      SafeFree(p_called_functions);
+      return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
   }
   used_variable_count = 0;
+  used_acessed_count = 0;
   for (size_t i = 0, j = 0; i < called_function_count; ++i) {
     while (p_parser->functions[j].id != p_called_functions[i]) {
       ++j;
@@ -3344,6 +3488,12 @@ static SpvReflectResult ParseStaticallyUsedResources(
            p_parser->functions[j].accessed_ptrs,
            p_parser->functions[j].accessed_ptr_count * sizeof(*used_variables));
     used_variable_count += p_parser->functions[j].accessed_ptr_count;
+
+    memcpy(&used_accesses[used_acessed_count],
+           p_parser->functions[j].accessed_variable_ptrs,
+           p_parser->functions[j].accessed_variable_ptr_count *
+               sizeof(SpvReflectPrvAccessedVariable));
+    used_acessed_count += p_parser->functions[j].accessed_variable_ptr_count;
   }
   SafeFree(p_called_functions);
 
@@ -3375,18 +3525,18 @@ static SpvReflectResult ParseStaticallyUsedResources(
     &p_entry->used_push_constants,
     &used_push_constant_count);
 
-  for (uint32_t j = 0; j < p_module->descriptor_binding_count; ++j) {
-    SpvReflectDescriptorBinding* p_binding = &p_module->descriptor_bindings[j];
-    bool found = SearchSortedUint32(
-      used_variables,
-      used_variable_count,
-      p_binding->spirv_id);
-    if (found) {
-      p_binding->accessed = 1;
+  for (uint32_t i = 0; i < p_module->descriptor_binding_count; ++i) {
+    SpvReflectDescriptorBinding* p_binding = &p_module->descriptor_bindings[i];
+    for (uint32_t j = 0; j < used_acessed_count; j++) {
+      if (used_accesses[j].variable_ptr == p_binding->spirv_id) {
+        p_binding->accessed = 1;
+        p_binding->access_flags |= used_accesses[j].access_flags;
+      }
     }
   }
 
   SafeFree(used_variables);
+  SafeFree(used_accesses);
   if (result0 != SPV_REFLECT_RESULT_SUCCESS) {
     return result0;
   }

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -262,6 +262,23 @@ typedef enum SpvReflectShaderStageFlagBits {
 
 } SpvReflectShaderStageFlagBits;
 
+/*! @enum SpvReflectAccessBits
+
+NOTE: A variable may be "accessed" but still have SPV_REFLECT_ACCESS_NONE
+      Example is if there is a OpAccessChain, but then it is never used
+
+*/
+typedef enum SpvReflectAccessFlagBits {
+  SPV_REFLECT_ACCESS_NONE   = 0x00000000,
+  SPV_REFLECT_ACCESS_READ   = 0x00000001,
+  SPV_REFLECT_ACCESS_WRITE  = 0x00000002,
+  // OpAtomicLoad/OpAtomicStore are only marked as ATOMIC
+  // Operations in spec are defined as "load, store, and atomic"
+  SPV_REFLECT_ACCESS_ATOMIC = 0x00000004,
+} SpvReflectAccessFlagBits;
+
+typedef uint32_t SpvReflectAccessFlags;
+
 /*! @enum SpvReflectGenerator
 
 */
@@ -440,6 +457,7 @@ typedef struct SpvReflectDescriptorBinding {
   SpvReflectBindingArrayTraits        array;
   uint32_t                            count;
   uint32_t                            accessed;
+  SpvReflectAccessFlags               access_flags;
   uint32_t                            uav_counter_id;
   struct SpvReflectDescriptorBinding* uav_counter_binding;
 

--- a/tests/access_chains/array_length_from_access_chain.spv.yaml
+++ b/tests/access_chains/array_length_from_access_chain.spv.yaml
@@ -115,6 +115,7 @@ all_descriptor_bindings:
     block: *bv2 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/cbuffer_unused/cbuffer_unused_001.spv.yaml
+++ b/tests/cbuffer_unused/cbuffer_unused_001.spv.yaml
@@ -3309,6 +3309,7 @@ all_descriptor_bindings:
     block: *bv63 # "MyParams"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td63
@@ -3325,6 +3326,7 @@ all_descriptor_bindings:
     block: *bv95 # "MyParams2"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td95

--- a/tests/entry_exec_mode/comp_local_size.spv.yaml
+++ b/tests/entry_exec_mode/comp_local_size.spv.yaml
@@ -81,6 +81,7 @@ all_descriptor_bindings:
     block: *bv1 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000003 # READ WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1

--- a/tests/glsl/buffer_handle_0.spv.yaml
+++ b/tests/glsl/buffer_handle_0.spv.yaml
@@ -1348,6 +1348,7 @@ all_descriptor_bindings:
     block: *bv8 # "s5"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td8
@@ -1364,6 +1365,7 @@ all_descriptor_bindings:
     block: *bv20 # "x"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td55

--- a/tests/glsl/buffer_handle_1.spv.yaml
+++ b/tests/glsl/buffer_handle_1.spv.yaml
@@ -665,6 +665,7 @@ all_descriptor_bindings:
     block: *bv5 # "s5"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000003 # READ WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td5
@@ -681,6 +682,7 @@ all_descriptor_bindings:
     block: *bv12 # "x"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td24

--- a/tests/glsl/buffer_handle_2.spv.yaml
+++ b/tests/glsl/buffer_handle_2.spv.yaml
@@ -1003,6 +1003,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000003 # READ WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -1019,6 +1020,7 @@ all_descriptor_bindings:
     block: *bv21 # "x"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td17

--- a/tests/glsl/buffer_handle_3.spv.yaml
+++ b/tests/glsl/buffer_handle_3.spv.yaml
@@ -404,6 +404,7 @@ all_descriptor_bindings:
     block: *bv4 # "s5"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td4
@@ -420,6 +421,7 @@ all_descriptor_bindings:
     block: *bv8 # "x"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td13

--- a/tests/glsl/fn_struct_param.spv.yaml
+++ b/tests/glsl/fn_struct_param.spv.yaml
@@ -132,6 +132,7 @@ all_descriptor_bindings:
     block: *bv2 # "test"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/glsl/input_attachment.spv.yaml
+++ b/tests/glsl/input_attachment.spv.yaml
@@ -94,6 +94,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -110,6 +111,7 @@ all_descriptor_bindings:
     block: *bv1 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -126,6 +128,7 @@ all_descriptor_bindings:
     block: *bv2 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/glsl/matrix_major_order_glsl.spv.yaml
+++ b/tests/glsl/matrix_major_order_glsl.spv.yaml
@@ -982,6 +982,7 @@ all_descriptor_bindings:
     block: *bv27 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td27

--- a/tests/glsl/non_writable_image.spv.yaml
+++ b/tests/glsl/non_writable_image.spv.yaml
@@ -79,6 +79,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -95,6 +96,7 @@ all_descriptor_bindings:
     block: *bv1 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000003 # READ WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/glsl/runtime_array_of_array_of_struct.spv.yaml
+++ b/tests/glsl/runtime_array_of_array_of_struct.spv.yaml
@@ -300,6 +300,7 @@ all_descriptor_bindings:
     block: *bv3 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td3
@@ -316,6 +317,7 @@ all_descriptor_bindings:
     block: *bv7 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td7

--- a/tests/glsl/storage_buffer.spv.yaml
+++ b/tests/glsl/storage_buffer.spv.yaml
@@ -164,6 +164,7 @@ all_descriptor_bindings:
     block: *bv1 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1
@@ -180,6 +181,7 @@ all_descriptor_bindings:
     block: *bv3 # ""
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000002 # WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td3

--- a/tests/glsl/texel_buffer.spv.yaml
+++ b/tests/glsl/texel_buffer.spv.yaml
@@ -185,6 +185,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -201,6 +202,7 @@ all_descriptor_bindings:
     block: *bv1 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1

--- a/tests/hlsl/append_consume.spv.yaml
+++ b/tests/hlsl/append_consume.spv.yaml
@@ -329,6 +329,7 @@ all_descriptor_bindings:
     block: *bv6 # "counter.var.BufferIn"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000004 # ATOMIC 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td4
@@ -345,6 +346,7 @@ all_descriptor_bindings:
     block: *bv2 # "BufferIn"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 11
     uav_counter_binding: *db0 # "counter.var.BufferIn"
     type_description: *td2
@@ -361,6 +363,7 @@ all_descriptor_bindings:
     block: *bv4 # "counter.var.BufferOut"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000004 # ATOMIC 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td4
@@ -378,6 +381,7 @@ all_descriptor_bindings:
     block: *bv9 # "BufferOut"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000002 # WRITE 
     uav_counter_id: 15
     uav_counter_binding: *db2 # "counter.var.BufferOut"
     type_description: *td7

--- a/tests/hlsl/array_of_structured_buffer.spv.yaml
+++ b/tests/hlsl/array_of_structured_buffer.spv.yaml
@@ -164,6 +164,7 @@ all_descriptor_bindings:
     block: *bv1 # "Input"
     array: { dims_count: 1, dims: [16,] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1
@@ -180,6 +181,7 @@ all_descriptor_bindings:
     block: *bv3 # "Output"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000002 # WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td3

--- a/tests/hlsl/binding_array.spv.yaml
+++ b/tests/hlsl/binding_array.spv.yaml
@@ -96,6 +96,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 1, dims: [6,] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -112,6 +113,7 @@ all_descriptor_bindings:
     block: *bv1 # 
     array: { dims_count: 1, dims: [2,] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1

--- a/tests/hlsl/binding_types.spv.yaml
+++ b/tests/hlsl/binding_types.spv.yaml
@@ -1332,6 +1332,7 @@ all_descriptor_bindings:
     block: *bv1 # "MyCBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1
@@ -1348,6 +1349,7 @@ all_descriptor_bindings:
     block: *bv3 # "MyConstantBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td3
@@ -1364,6 +1366,7 @@ all_descriptor_bindings:
     block: *bv4 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td4
@@ -1380,6 +1383,7 @@ all_descriptor_bindings:
     block: *bv5 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td5
@@ -1396,6 +1400,7 @@ all_descriptor_bindings:
     block: *bv6 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td6
@@ -1412,6 +1417,7 @@ all_descriptor_bindings:
     block: *bv7 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td7
@@ -1428,6 +1434,7 @@ all_descriptor_bindings:
     block: *bv8 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td8
@@ -1444,6 +1451,7 @@ all_descriptor_bindings:
     block: *bv9 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td9
@@ -1460,6 +1468,7 @@ all_descriptor_bindings:
     block: *bv10 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td10
@@ -1476,6 +1485,7 @@ all_descriptor_bindings:
     block: *bv11 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td11
@@ -1492,6 +1502,7 @@ all_descriptor_bindings:
     block: *bv12 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td12
@@ -1508,6 +1519,7 @@ all_descriptor_bindings:
     block: *bv13 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td13
@@ -1524,6 +1536,7 @@ all_descriptor_bindings:
     block: *bv14 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td14
@@ -1540,6 +1553,7 @@ all_descriptor_bindings:
     block: *bv15 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td15
@@ -1556,6 +1570,7 @@ all_descriptor_bindings:
     block: *bv16 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td16
@@ -1572,6 +1587,7 @@ all_descriptor_bindings:
     block: *bv17 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td17
@@ -1588,6 +1604,7 @@ all_descriptor_bindings:
     block: *bv19 # "MyTBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td19
@@ -1604,6 +1621,7 @@ all_descriptor_bindings:
     block: *bv21 # "MyTextureBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td21
@@ -1620,6 +1638,7 @@ all_descriptor_bindings:
     block: *bv22 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td22
@@ -1636,6 +1655,7 @@ all_descriptor_bindings:
     block: *bv23 # 
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td23
@@ -1652,6 +1672,7 @@ all_descriptor_bindings:
     block: *bv25 # "MyStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td25
@@ -1668,6 +1689,7 @@ all_descriptor_bindings:
     block: *bv29 # "counter.var.MyRWStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td29
@@ -1684,6 +1706,7 @@ all_descriptor_bindings:
     block: *bv27 # "MyRWStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 74
     uav_counter_binding: *db21 # "counter.var.MyRWStructuredBuffer"
     type_description: *td27
@@ -1701,6 +1724,7 @@ all_descriptor_bindings:
     block: *bv33 # "counter.var.MyAppendStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td29
@@ -1717,6 +1741,7 @@ all_descriptor_bindings:
     block: *bv31 # "MyAppendStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 78
     uav_counter_binding: *db23 # "counter.var.MyAppendStructuredBuffer"
     type_description: *td31
@@ -1734,6 +1759,7 @@ all_descriptor_bindings:
     block: *bv37 # "counter.var.MyConsumeStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td29
@@ -1750,6 +1776,7 @@ all_descriptor_bindings:
     block: *bv35 # "MyConsumeStructuredBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 82
     uav_counter_binding: *db25 # "counter.var.MyConsumeStructuredBuffer"
     type_description: *td33
@@ -1767,6 +1794,7 @@ all_descriptor_bindings:
     block: *bv39 # "MyByteAddressBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td35
@@ -1783,6 +1811,7 @@ all_descriptor_bindings:
     block: *bv41 # "MyRWByteAddressBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td37

--- a/tests/hlsl/cbuffer.spv.yaml
+++ b/tests/hlsl/cbuffer.spv.yaml
@@ -880,6 +880,7 @@ all_descriptor_bindings:
     block: *bv24 # "MyCBuffer"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td24

--- a/tests/hlsl/constantbuffer.spv.yaml
+++ b/tests/hlsl/constantbuffer.spv.yaml
@@ -969,6 +969,7 @@ all_descriptor_bindings:
     block: *bv24 # "MyConstants"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td24

--- a/tests/hlsl/constantbuffer_nested_structs.spv.yaml
+++ b/tests/hlsl/constantbuffer_nested_structs.spv.yaml
@@ -6613,6 +6613,7 @@ all_descriptor_bindings:
     block: *bv190 # "MyConstants"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td190

--- a/tests/hlsl/counter_buffers.spv.yaml
+++ b/tests/hlsl/counter_buffers.spv.yaml
@@ -397,6 +397,7 @@ all_descriptor_bindings:
     block: *bv1 # "counter.var.MyBufferIn"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000004 # ATOMIC 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1
@@ -413,6 +414,7 @@ all_descriptor_bindings:
     block: *bv3 # "counter.var.MyBufferOut"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000004 # ATOMIC 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1
@@ -429,6 +431,7 @@ all_descriptor_bindings:
     block: *bv7 # "MyBufferIn"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 12
     uav_counter_binding: *db0 # "counter.var.MyBufferIn"
     type_description: *td5
@@ -445,6 +448,7 @@ all_descriptor_bindings:
     block: *bv11 # "MyBufferOut"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000002 # WRITE 
     uav_counter_id: 16
     uav_counter_binding: *db1 # "counter.var.MyBufferOut"
     type_description: *td9

--- a/tests/hlsl/matrix_major_order_hlsl.spv.yaml
+++ b/tests/hlsl/matrix_major_order_hlsl.spv.yaml
@@ -982,6 +982,7 @@ all_descriptor_bindings:
     block: *bv27 # "$Globals"
     array: { dims_count: 0, dims: [] }
     accessed: 0
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td27

--- a/tests/hlsl/semantics.spv.yaml
+++ b/tests/hlsl/semantics.spv.yaml
@@ -268,6 +268,7 @@ all_descriptor_bindings:
     block: *bv4 # "MyConstants"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td4

--- a/tests/hlsl/structuredbuffer.spv.yaml
+++ b/tests/hlsl/structuredbuffer.spv.yaml
@@ -574,6 +574,7 @@ all_descriptor_bindings:
     block: *bv15 # "MyData"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td15

--- a/tests/issues/77/hlsl/array_from_ubo.spv.yaml
+++ b/tests/issues/77/hlsl/array_from_ubo.spv.yaml
@@ -149,6 +149,7 @@ all_descriptor_bindings:
     block: *bv2 # "_cbPerObjectBones"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/issues/77/hlsl/array_from_ubo_with_O0.spv.yaml
+++ b/tests/issues/77/hlsl/array_from_ubo_with_O0.spv.yaml
@@ -149,6 +149,7 @@ all_descriptor_bindings:
     block: *bv2 # "_cbPerObjectBones"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/issues/77/hlsl/rocketz.spv.yaml
+++ b/tests/issues/77/hlsl/rocketz.spv.yaml
@@ -149,6 +149,7 @@ all_descriptor_bindings:
     block: *bv2 # "_cbPerObjectBones"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000000 # NONE
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/multi_entrypoint/multi_entrypoint.spv.yaml
+++ b/tests/multi_entrypoint/multi_entrypoint.spv.yaml
@@ -314,6 +314,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -330,6 +331,7 @@ all_descriptor_bindings:
     block: *bv2 # "ubo"
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td2

--- a/tests/raytrace/rayquery_equal.cs.spv.yaml
+++ b/tests/raytrace/rayquery_equal.cs.spv.yaml
@@ -96,6 +96,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0
@@ -112,6 +113,7 @@ all_descriptor_bindings:
     block: *bv1 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000003 # READ WRITE 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td1

--- a/tests/raytrace/rayquery_init_ds.spv.yaml
+++ b/tests/raytrace/rayquery_init_ds.spv.yaml
@@ -132,6 +132,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_gs.spv.yaml
+++ b/tests/raytrace/rayquery_init_gs.spv.yaml
@@ -64,6 +64,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_hs.spv.yaml
+++ b/tests/raytrace/rayquery_init_hs.spv.yaml
@@ -115,6 +115,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_ps.spv.yaml
+++ b/tests/raytrace/rayquery_init_ps.spv.yaml
@@ -64,6 +64,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_rahit.spv.yaml
+++ b/tests/raytrace/rayquery_init_rahit.spv.yaml
@@ -47,6 +47,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_rcall.spv.yaml
+++ b/tests/raytrace/rayquery_init_rcall.spv.yaml
@@ -47,6 +47,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_rchit.spv.yaml
+++ b/tests/raytrace/rayquery_init_rchit.spv.yaml
@@ -47,6 +47,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_rgen.spv.yaml
+++ b/tests/raytrace/rayquery_init_rgen.spv.yaml
@@ -47,6 +47,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/rayquery_init_rmiss.spv.yaml
+++ b/tests/raytrace/rayquery_init_rmiss.spv.yaml
@@ -47,6 +47,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/raytracing.khr.closesthit.spv.yaml
+++ b/tests/raytrace/raytracing.khr.closesthit.spv.yaml
@@ -132,6 +132,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/raytracing.nv.closesthit.spv.yaml
+++ b/tests/raytrace/raytracing.nv.closesthit.spv.yaml
@@ -132,6 +132,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/raytracing.nv.enum.spv.yaml
+++ b/tests/raytrace/raytracing.nv.enum.spv.yaml
@@ -64,6 +64,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/raytracing.nv.library.spv.yaml
+++ b/tests/raytrace/raytracing.nv.library.spv.yaml
@@ -132,6 +132,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/raytrace/raytracing.nv.raygen.spv.yaml
+++ b/tests/raytrace/raytracing.nv.raygen.spv.yaml
@@ -64,6 +64,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0

--- a/tests/spirv15/VertexShader.spv.yaml
+++ b/tests/spirv15/VertexShader.spv.yaml
@@ -81,6 +81,7 @@ all_descriptor_bindings:
     block: *bv0 # 
     array: { dims_count: 0, dims: [] }
     accessed: 1
+    access_flags: 0x00000001 # READ 
     uav_counter_id: 4294967295
     uav_counter_binding:
     type_description: *td0


### PR DESCRIPTION
closes https://github.com/KhronosGroup/SPIRV-Reflect/issues/222

WIP because

1. Want to review and examine tests
2. Want to try to use the other `used_variables` allocation together with the new one added
3. Need to look into `OpCopy*` operations as currently don't think we walk it even for normal `accessed`