### PR TITLE
add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# rerun clang-format with 132 line width
+dc6582bf8c1520a632dca98b11974048ad89fe16


### PR DESCRIPTION
@cassiebeckley this is part 2 of the clang-format churn. Tools like github, will now just ignore that commit and keep `git blame` working as expected