### PR TITLE
Print Spec Constant value in type array by default

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -1723,7 +1723,6 @@ void SpvReflectToYaml::WriteBlockVariable(std::ostream& os, const SpvReflectBloc
   os << t2 << "matrix: { ";
   os << "column_count: " << bv.numeric.matrix.column_count << ", ";
   os << "row_count: " << bv.numeric.matrix.row_count << ", ";
-  ;
   os << "stride: " << bv.numeric.matrix.stride << " }" << std::endl;
   // } SpvReflectNumericTraits;
 
@@ -1946,7 +1945,6 @@ void SpvReflectToYaml::WriteInterfaceVariable(std::ostream& os, const SpvReflect
   os << t2 << "matrix: { ";
   os << "column_count: " << iv.numeric.matrix.column_count << ", ";
   os << "row_count: " << iv.numeric.matrix.row_count << ", ";
-  ;
   os << "stride: " << iv.numeric.matrix.stride << " }" << std::endl;
   // } SpvReflectNumericTraits;
 

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -321,7 +321,6 @@ typedef struct SpvReflectImageTraits {
 
 typedef enum SpvReflectArrayDimType {
   SPV_REFLECT_ARRAY_DIM_RUNTIME       = 0,         // OpTypeRuntimeArray
-  SPV_REFLECT_ARRAY_DIM_SPEC_CONSTANT = 0xFFFFFFFF // specialization constant
 } SpvReflectArrayDimType;
 
 typedef struct SpvReflectArrayTraits {


### PR DESCRIPTION
Instead of printing a mysterious `0xFFFFFFFF`, print the default spec constant value and make use of the `spec_constant_op_ids` field

so something like 

```
layout(constant_id = 3) const int SIZE = 2;
layout(set = 0, binding = 0, std430) buffer SSBO {
    float val[SIZE];
} ssbo;
```

now shows

```patch
// SpvReflectArrayTraits
dims_count = 0
- dims = [0xFFFFFFFF]
- spec_constant_op_ids = [constant_id]
+ dims = [2]
+ spec_constant_op_ids = [3]
```

(cc @muraj @zbendefy it would be awesome to get feedback if this helps solve your problems or not)