### PR TITLE
Fix and improve CI Testing of database shader

### DIFF
--- a/.github/workflows/linux-cmake-build.yml
+++ b/.github/workflows/linux-cmake-build.yml
@@ -40,19 +40,19 @@ jobs:
           git clone https://github.com/LunarG/SPIRV-Database.git build/SPIRV-Database
       - name: Test - SaschaWillemsVulkan
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/SaschaWillemsVulkan/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/SaschaWillemsVulkan/
       - name: Test - clspv
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/clspv/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/clspv/
       - name: Test - dawn
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/dawn/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/dawn/
       - name: Test - gl_cts
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/gl_cts/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/gl_cts/
       - name: Test - naga
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/naga/remaps/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/naga/remaps/
       - name: Test - tint
         run: |
-          for spv in $(find build/SPIRV-Database/vulkan/tint/ -type f); do bin/spirv-reflect $spv -ci; done
+          python tests/ci_database.py --dir build/SPIRV-Database/vulkan/tint/

--- a/tests/ci_database.py
+++ b/tests/ci_database.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import argparse
+import subprocess
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='run SPIRV-Database in CI')
+    # Main reason for passing dir in is so GitHub Actions can group things, otherwise logs get VERY long for a single action
+    parser.add_argument('--dir', action='store', required=True, type=str, help='path to SPIR-V files')
+    args = parser.parse_args()
+
+    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    exe_path = os.path.join(root_dir, 'bin/spirv-reflect')
+
+    for currentpath, folders, files in os.walk(args.dir):
+        for file in files:
+            spirv_file = os.path.join(currentpath, file)
+            command = f'{exe_path} {spirv_file} -ci'
+            exit_code = subprocess.call(command.split())
+            if exit_code != 0:
+                print(f'ERROR for {spirv_file}')
+                sys.exit(1)


### PR DESCRIPTION
Before we were not actually failing CI if a shader crashed, new script added to check return code and produce an error as that found in the https://github.com/KhronosGroup/SPIRV-Reflect/pull/244 test