### PR TITLE
Parse name of specialization constants

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -2253,6 +2253,7 @@ void SpvReflectToYaml::Write(std::ostream& os) {
   os << t1 << "specialization_constants:" << std::endl;
   for (uint32_t i = 0; i < sm_.spec_constant_count; ++i) {
     os << t3 << "spirv_id: " << sm_.spec_constants[i].spirv_id << std::endl;
+    os << t3 << "name: " << sm_.spec_constants[i].name << std::endl;
     os << t3 << "constant_id: " << sm_.spec_constants[i].constant_id << std::endl;
   }
 

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1652,8 +1652,13 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser, SpvRefle
       CHECKED_READU32(p_parser, p_node->word_offset + 2, decoration);
       if (decoration == SpvDecorationSpecId) {
         const uint32_t count = p_module->spec_constant_count;
-        CHECKED_READU32(p_parser, p_node->word_offset + 1, p_module->spec_constants[count].constant_id);
-        CHECKED_READU32(p_parser, p_node->word_offset + 3, p_module->spec_constants[count].spirv_id);
+        CHECKED_READU32(p_parser, p_node->word_offset + 1, p_module->spec_constants[count].spirv_id);
+        CHECKED_READU32(p_parser, p_node->word_offset + 3, p_module->spec_constants[count].constant_id);
+        SpvReflectPrvNode* target_node = FindNode(p_parser, p_module->spec_constants[count].spirv_id);
+        if (IsNull(target_node)) {
+            return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+        }
+        p_module->spec_constants[count].name = target_node->name;
         p_module->spec_constant_count++;
       }
     }

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -560,6 +560,7 @@ typedef struct SpvReflectCapability {
 */
 typedef struct SpvReflectSpecializationConstant {
   uint32_t spirv_id;
+  const char* name;
   uint32_t constant_id;
 } SpvReflectSpecializationConstant;
 


### PR DESCRIPTION
Parses names of specialization constants, also fixes parsing of spirv_id and constant_id (I think these were swapped when being parsed from the bytecode)

I still have to update the test yaml files to include the names, also I think this doesn't work yet for compute group size constants.