### PR TITLE
Remove word duplicates in `spirv_reflect.c`

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1440,7 +1440,7 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser, SpvRefle
     }
     // Get decorations
     SpvReflectPrvDecorations* p_target_decorations = &(p_target_node->decorations);
-    // Update pointer if this is a member member decoration
+    // Update pointer if this is a member decoration
     if (p_node->op == SpvOpMemberDecorate) {
       uint32_t member_index = (uint32_t)INVALID_VALUE;
       CHECKED_READU32(p_parser, p_node->word_offset + 2, member_index);

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -1426,7 +1426,7 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser, SpvRefle
       continue;
     }
 
-    // Find target target node
+    // Find target node
     uint32_t target_id = 0;
     CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
     SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);


### PR DESCRIPTION
Quick fix for a repetition of the words "target" and "member" in the comments.
