### PR TITLE
Fix SpvReflectEntryPoint::output_vertices being stomped by other execution modes

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -3770,13 +3770,6 @@ static SpvReflectResult ParseExecutionModes(SpvReflectPrvParser* p_parser, SpvRe
           }
         } break;
 
-        case SpvExecutionModeInputPoints:
-        case SpvExecutionModeInputLines:
-        case SpvExecutionModeInputLinesAdjacency:
-        case SpvExecutionModeTriangles:
-        case SpvExecutionModeInputTrianglesAdjacency:
-        case SpvExecutionModeQuads:
-        case SpvExecutionModeIsolines:
         case SpvExecutionModeOutputVertices: {
           CHECKED_READU32(p_parser, p_node->word_offset + 3, p_entry_point->output_vertices);
         } break;


### PR DESCRIPTION
These execution modes set and stomp output_vertices with invalid data since they have no extra operands.

```
[4]  OpExecutionMode %2 OutputVertices 128
[5]  OpExecutionMode %2 Invocations 1
[6]  OpExecutionMode %2 InputPoints
```

With this SPIRV generated by DXC InputPoints would stomp the OutputVertices value to a non-existent value