### PR TITLE
fallthrough attribute was introduced only in GCC 7.0

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #endif
 
-#if defined(__clang__) || defined(__GNUC__) || defined(__APPLE_CC__)
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7) || defined(__APPLE_CC__)
 #define FALLTHROUGH __attribute__((fallthrough))
 #else
 #define FALLTHROUGH


### PR DESCRIPTION
https://stackoverflow.com/questions/45349079/how-to-use-attribute-fallthrough-correctly-in-gcc