### PR TITLE
Fix struct variable size with out-of-order offsets

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2751,13 +2751,15 @@ static SpvReflectResult ParseDescriptorBlockVariableSizes(SpvReflectPrvParser* p
 
   // ...last entry just gets rounded up to near multiple of SPIRV_DATA_ALIGNMENT, which is 16 and
   // subtract the offset.
-  SpvReflectBlockVariable* p_member_var = pp_member_offset_order[p_var->member_count - 1];
-  p_member_var->padded_size = RoundUp(p_member_var->offset + p_member_var->size, SPIRV_DATA_ALIGNMENT) - p_member_var->offset;
-  if (p_member_var->size > p_member_var->padded_size) {
-    p_member_var->size = p_member_var->padded_size;
+  // last entry == entry with largest offset value
+  SpvReflectBlockVariable* p_last_member_var = pp_member_offset_order[p_var->member_count - 1];
+  p_last_member_var->padded_size =
+      RoundUp(p_last_member_var->offset + p_last_member_var->size, SPIRV_DATA_ALIGNMENT) - p_last_member_var->offset;
+  if (p_last_member_var->size > p_last_member_var->padded_size) {
+    p_last_member_var->size = p_last_member_var->padded_size;
   }
   if (is_parent_rta) {
-    p_member_var->padded_size = p_member_var->size;
+    p_last_member_var->padded_size = p_last_member_var->size;
   }
 
   SafeFree(pp_member_offset_order);
@@ -2769,7 +2771,7 @@ static SpvReflectResult ParseDescriptorBlockVariableSizes(SpvReflectPrvParser* p
   }
 
   // @TODO validate this with assertion
-  p_var->size = p_var->members[p_var->member_count - 1].offset + p_var->members[p_var->member_count - 1].padded_size;
+  p_var->size = p_last_member_var->offset + p_last_member_var->padded_size;
   p_var->padded_size = p_var->size;
 
   return SPV_REFLECT_RESULT_SUCCESS;

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2711,58 +2711,56 @@ static SpvReflectResult ParseDescriptorBlockVariableSizes(SpvReflectPrvParser* p
     }
   }
 
-  if (p_var->member_count > 0) {
-    // Structs can offset order don't need to match the index order, so first order by offset
-    // example:
-    //     OpMemberDecorate %struct 0 Offset 4
-    //     OpMemberDecorate %struct 1 Offset 0
-    SpvReflectBlockVariable** pp_member_offset_order =
-        (SpvReflectBlockVariable**)calloc(p_var->member_count, sizeof(SpvReflectBlockVariable*));
-    if (IsNull(pp_member_offset_order)) {
-      return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
-    }
+  // Structs can offset order don't need to match the index order, so first order by offset
+  // example:
+  //     OpMemberDecorate %struct 0 Offset 4
+  //     OpMemberDecorate %struct 1 Offset 0
+  SpvReflectBlockVariable** pp_member_offset_order =
+      (SpvReflectBlockVariable**)calloc(p_var->member_count, sizeof(SpvReflectBlockVariable*));
+  if (IsNull(pp_member_offset_order)) {
+    return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+  }
 
-    uint32_t bottom_bound = 0;
-    for (uint32_t i = 0; i < p_var->member_count; ++i) {
-      uint32_t lowest_offset = UINT32_MAX;
-      uint32_t member_index = 0;
-      for (uint32_t j = 0; j < p_var->member_count; ++j) {
-        const uint32_t offset = p_var->members[j].offset;
-        if (offset < lowest_offset && offset >= bottom_bound) {
-          member_index = j;
-          lowest_offset = offset;
-        }
-      }
-      pp_member_offset_order[i] = &p_var->members[member_index];
-      bottom_bound = lowest_offset + 1;  // 2 index can't share the same offset
-    }
-
-    // Parse padded size using offset difference for all member except for the last entry...
-    for (uint32_t i = 0; i < (p_var->member_count - 1); ++i) {
-      SpvReflectBlockVariable* p_member_var = pp_member_offset_order[i];
-      SpvReflectBlockVariable* p_next_member_var = pp_member_offset_order[i + 1];
-      p_member_var->padded_size = p_next_member_var->offset - p_member_var->offset;
-      if (p_member_var->size > p_member_var->padded_size) {
-        p_member_var->size = p_member_var->padded_size;
-      }
-      if (is_parent_rta) {
-        p_member_var->padded_size = p_member_var->size;
+  uint32_t bottom_bound = 0;
+  for (uint32_t i = 0; i < p_var->member_count; ++i) {
+    uint32_t lowest_offset = UINT32_MAX;
+    uint32_t member_index = 0;
+    for (uint32_t j = 0; j < p_var->member_count; ++j) {
+      const uint32_t offset = p_var->members[j].offset;
+      if (offset < lowest_offset && offset >= bottom_bound) {
+        member_index = j;
+        lowest_offset = offset;
       }
     }
+    pp_member_offset_order[i] = &p_var->members[member_index];
+    bottom_bound = lowest_offset + 1;  // 2 index can't share the same offset
+  }
 
-    // ...last entry just gets rounded up to near multiple of SPIRV_DATA_ALIGNMENT, which is 16 and
-    // subtract the offset.
-    SpvReflectBlockVariable* p_member_var = pp_member_offset_order[p_var->member_count - 1];
-    p_member_var->padded_size = RoundUp(p_member_var->offset + p_member_var->size, SPIRV_DATA_ALIGNMENT) - p_member_var->offset;
+  // Parse padded size using offset difference for all member except for the last entry...
+  for (uint32_t i = 0; i < (p_var->member_count - 1); ++i) {
+    SpvReflectBlockVariable* p_member_var = pp_member_offset_order[i];
+    SpvReflectBlockVariable* p_next_member_var = pp_member_offset_order[i + 1];
+    p_member_var->padded_size = p_next_member_var->offset - p_member_var->offset;
     if (p_member_var->size > p_member_var->padded_size) {
       p_member_var->size = p_member_var->padded_size;
     }
     if (is_parent_rta) {
       p_member_var->padded_size = p_member_var->size;
     }
-
-    SafeFree(pp_member_offset_order);
   }
+
+  // ...last entry just gets rounded up to near multiple of SPIRV_DATA_ALIGNMENT, which is 16 and
+  // subtract the offset.
+  SpvReflectBlockVariable* p_member_var = pp_member_offset_order[p_var->member_count - 1];
+  p_member_var->padded_size = RoundUp(p_member_var->offset + p_member_var->size, SPIRV_DATA_ALIGNMENT) - p_member_var->offset;
+  if (p_member_var->size > p_member_var->padded_size) {
+    p_member_var->size = p_member_var->padded_size;
+  }
+  if (is_parent_rta) {
+    p_member_var->padded_size = p_member_var->size;
+  }
+
+  SafeFree(pp_member_offset_order);
 
   // If buffer ref, sizes are same as uint64_t
   if (is_parent_ref) {

--- a/tests/glsl/struct_offset_order.spv.yaml
+++ b/tests/glsl/struct_offset_order.spv.yaml
@@ -323,8 +323,8 @@ all_block_variables:
     name: "ubo2"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 32
+    padded_size: 32
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/push_constants/non_zero_block_offset.spv.yaml
+++ b/tests/push_constants/non_zero_block_offset.spv.yaml
@@ -211,8 +211,8 @@ all_block_variables:
     name: "pc"
     offset: 4
     absolute_offset: 0
-    size: 8
-    padded_size: 8
+    size: 32
+    padded_size: 32
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }


### PR DESCRIPTION
This is follow-up for https://github.com/KhronosGroup/SPIRV-Reflect/pull/263

I realize the struct size itself is still wrong

```
name     : ubo (UniformBufferObject)
    // size = 16, padded size = 16
    struct UniformBufferObject {
        float a; // abs offset = 0, rel offset = 0, size = 4, padded size =  4 UNUSED
        float b; // abs offset = 4, rel offset = 4, size = 4, padded size = 12 UNUSED
    } ubo;      

name     : ubo2 (UniformBufferObject2)
    // size = 4, padded size = 4
    struct UniformBufferObject2 {
        float b; // abs offset = 4, rel offset = 4, size = 4, padded size = 12 UNUSED
        float a; // abs offset = 0, rel offset = 0, size = 4, padded size =  4 UNUSED
    } ubo2;     
```

The size of `ubo2` is not `// size = 4, padded size = 4` and should be `16`
