### PR TITLE
Fix specialization_constants items

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -2282,7 +2282,7 @@ void SpvReflectToYaml::Write(std::ostream& os) {
   // SpvReflectSpecializationConstant*   spec_constants;
   os << t1 << "specialization_constants:" << std::endl;
   for (uint32_t i = 0; i < sm_.spec_constant_count; ++i) {
-    os << t3 << "spirv_id: " << sm_.spec_constants[i].spirv_id << std::endl;
+    os << t2 << "- spirv_id: " << sm_.spec_constants[i].spirv_id << std::endl;
     os << t3 << "constant_id: " << sm_.spec_constants[i].constant_id << std::endl;
     os << t3 << "name: " << SafeString(sm_.spec_constants[i].name) << std::endl;
   }

--- a/tests/spec_constants/basic.spv.yaml
+++ b/tests/spec_constants/basic.spv.yaml
@@ -146,7 +146,7 @@ module:
   push_constants:
   specialization_constant_count: 1,
   specialization_constants:
-      spirv_id: 8
+    - spirv_id: 8
       constant_id: 3
       name: "SIZE"
 ...

--- a/tests/spec_constants/convert.spv.yaml
+++ b/tests/spec_constants/convert.spv.yaml
@@ -503,16 +503,16 @@ module:
   push_constants:
   specialization_constant_count: 4,
   specialization_constants:
-      spirv_id: 8
+    - spirv_id: 8
       constant_id: 0
       name: "SONE"
-      spirv_id: 19
+    - spirv_id: 19
       constant_id: 2
       name: "F_ONE"
-      spirv_id: 23
+    - spirv_id: 23
       constant_id: 1
       name: "UONE"
-      spirv_id: 36
+    - spirv_id: 36
       constant_id: 3
       name: "D_ONE"
 ...

--- a/tests/spec_constants/local_size_id_10.spv.yaml
+++ b/tests/spec_constants/local_size_id_10.spv.yaml
@@ -24,10 +24,10 @@ module:
   push_constants:
   specialization_constant_count: 2,
   specialization_constants:
-      spirv_id: 7
+    - spirv_id: 7
       constant_id: 8
-      name: 
-      spirv_id: 8
+      name:
+    - spirv_id: 8
       constant_id: 4
-      name: 
+      name:
 ...

--- a/tests/spec_constants/local_size_id_13.spv.yaml
+++ b/tests/spec_constants/local_size_id_13.spv.yaml
@@ -24,16 +24,16 @@ module:
   push_constants:
   specialization_constant_count: 4,
   specialization_constants:
-      spirv_id: 7
+    - spirv_id: 7
       constant_id: 8
-      name: 
-      spirv_id: 8
+      name:
+    - spirv_id: 8
       constant_id: 4
-      name: 
-      spirv_id: 10
+      name:
+    - spirv_id: 10
       constant_id: 8
-      name: 
-      spirv_id: 11
+      name:
+    - spirv_id: 11
       constant_id: 4
-      name: 
+      name:
 ...

--- a/tests/spec_constants/ssbo_array.spv.yaml
+++ b/tests/spec_constants/ssbo_array.spv.yaml
@@ -146,10 +146,10 @@ module:
   push_constants:
   specialization_constant_count: 2,
   specialization_constants:
-      spirv_id: 8
+    - spirv_id: 8
       constant_id: 8
       name: "SIZE_A"
-      spirv_id: 10
+    - spirv_id: 10
       constant_id: 5
       name: "SIZE_B"
 ...


### PR DESCRIPTION
`specialization_constants` block is missing item markers and the resulting YAML is treated like a map, failing on duplicate keys (`spirv_id`).