### PR TITLE
cmake: Add 'ARCHIVE DESTINATION' for static library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,8 @@ if(SPIRV_REFLECT_STATIC_LIB)
 
     target_include_directories(spirv-reflect-static
                                PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-    install(TARGETS spirv-reflect-static LIBRARY DESTINATION lib)
+    install(TARGETS spirv-reflect-static
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib)
 endif()
 


### PR DESCRIPTION
trying to compile as static lib, using android and older cmake 3.10 we ran into this error:

```
SPIRV-Reflect/CMakeLists.txt:116 (install):
        install TARGETS given no ARCHIVE DESTINATION for static library target
        "spirv-reflect-static".
```
