### PR TITLE
Fix generating invalid YAML files

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -2148,7 +2148,7 @@ void SpvReflectToYaml::Write(std::ostream& os) {
   const std::string t2 = Indent(indent_level + 2);
   const std::string t3 = Indent(indent_level + 3);
 
-  os << "%YAML 1.0" << std::endl;
+  os << "%YAML 1.1" << std::endl;
   os << "---" << std::endl;
 
   type_description_to_index_.clear();

--- a/tests/16bit/vert_in_out_16.spv.yaml
+++ b/tests/16bit/vert_in_out_16.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/access_chains/array_length_from_access_chain.spv.yaml
+++ b/tests/access_chains/array_length_from_access_chain.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/cbuffer_unused/cbuffer_unused_001.spv.yaml
+++ b/tests/cbuffer_unused/cbuffer_unused_001.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/entry_exec_mode/comp_local_size.spv.yaml
+++ b/tests/entry_exec_mode/comp_local_size.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/entry_exec_mode/geom_inv_out_vert.spv.yaml
+++ b/tests/entry_exec_mode/geom_inv_out_vert.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/execution_mode/local_size_id.spv.yaml
+++ b/tests/execution_mode/local_size_id.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/execution_mode/local_size_id_spec.spv.yaml
+++ b/tests/execution_mode/local_size_id_spec.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/glsl/buffer_handle_0.spv.yaml
+++ b/tests/glsl/buffer_handle_0.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_1.spv.yaml
+++ b/tests/glsl/buffer_handle_1.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_2.spv.yaml
+++ b/tests/glsl/buffer_handle_2.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_3.spv.yaml
+++ b/tests/glsl/buffer_handle_3.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_4.spv.yaml
+++ b/tests/glsl/buffer_handle_4.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_5.spv.yaml
+++ b/tests/glsl/buffer_handle_5.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_6.spv.yaml
+++ b/tests/glsl/buffer_handle_6.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_7.spv.yaml
+++ b/tests/glsl/buffer_handle_7.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_8.spv.yaml
+++ b/tests/glsl/buffer_handle_8.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_9.spv.yaml
+++ b/tests/glsl/buffer_handle_9.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_uvec2_pc.spv.yaml
+++ b/tests/glsl/buffer_handle_uvec2_pc.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_handle_uvec2_ssbo.spv.yaml
+++ b/tests/glsl/buffer_handle_uvec2_ssbo.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/buffer_pointer.spv.yaml
+++ b/tests/glsl/buffer_pointer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/built_in_format.spv.yaml
+++ b/tests/glsl/built_in_format.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/fn_struct_param.spv.yaml
+++ b/tests/glsl/fn_struct_param.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/frag_array_input.spv.yaml
+++ b/tests/glsl/frag_array_input.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/frag_barycentric.spv.yaml
+++ b/tests/glsl/frag_barycentric.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/input_attachment.spv.yaml
+++ b/tests/glsl/input_attachment.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/io_vars_vs.spv.yaml
+++ b/tests/glsl/io_vars_vs.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/matrix_major_order_glsl.spv.yaml
+++ b/tests/glsl/matrix_major_order_glsl.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/non_writable_image.spv.yaml
+++ b/tests/glsl/non_writable_image.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/readonly_writeonly.spv.yaml
+++ b/tests/glsl/readonly_writeonly.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/runtime_array_of_array_of_struct.spv.yaml
+++ b/tests/glsl/runtime_array_of_array_of_struct.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/storage_buffer.spv.yaml
+++ b/tests/glsl/storage_buffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/struct_offset_order.spv.yaml
+++ b/tests/glsl/struct_offset_order.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/glsl/texel_buffer.spv.yaml
+++ b/tests/glsl/texel_buffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/append_consume.spv.yaml
+++ b/tests/hlsl/append_consume.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/array_of_structured_buffer.spv.yaml
+++ b/tests/hlsl/array_of_structured_buffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/binding_array.spv.yaml
+++ b/tests/hlsl/binding_array.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/binding_types.spv.yaml
+++ b/tests/hlsl/binding_types.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/cbuffer.spv.yaml
+++ b/tests/hlsl/cbuffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/constantbuffer.spv.yaml
+++ b/tests/hlsl/constantbuffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/constantbuffer_nested_structs.spv.yaml
+++ b/tests/hlsl/constantbuffer_nested_structs.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/counter_buffers.spv.yaml
+++ b/tests/hlsl/counter_buffers.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/localsize.spv.yaml
+++ b/tests/hlsl/localsize.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/hlsl/matrix_major_order_hlsl.spv.yaml
+++ b/tests/hlsl/matrix_major_order_hlsl.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/pushconstant.spv.yaml
+++ b/tests/hlsl/pushconstant.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/semantics.spv.yaml
+++ b/tests/hlsl/semantics.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/structuredbuffer.spv.yaml
+++ b/tests/hlsl/structuredbuffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/hlsl/user_type.spv.yaml
+++ b/tests/hlsl/user_type.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/interface/geom_input_builtin_array.spv.yaml
+++ b/tests/interface/geom_input_builtin_array.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/interface/vertex_input_builtin_block.spv.yaml
+++ b/tests/interface/vertex_input_builtin_block.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/interface/vertex_input_builtin_non_block.spv.yaml
+++ b/tests/interface/vertex_input_builtin_non_block.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/102/function_parameter_access.spv.yaml
+++ b/tests/issues/102/function_parameter_access.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/178/vertex_input_struct.spv.yaml
+++ b/tests/issues/178/vertex_input_struct.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/178/vertex_input_struct2.spv.yaml
+++ b/tests/issues/178/vertex_input_struct2.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/227/null_node.spv.yaml
+++ b/tests/issues/227/null_node.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/77/hlsl/array_from_ubo.spv.yaml
+++ b/tests/issues/77/hlsl/array_from_ubo.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/77/hlsl/array_from_ubo_with_O0.spv.yaml
+++ b/tests/issues/77/hlsl/array_from_ubo_with_O0.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/issues/77/hlsl/rocketz.spv.yaml
+++ b/tests/issues/77/hlsl/rocketz.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/mesh_shader_ext/mesh_shader_ext.mesh.hlsl.spv.yaml
+++ b/tests/mesh_shader_ext/mesh_shader_ext.mesh.hlsl.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/mesh_shader_ext/mesh_shader_ext.task.hlsl.spv.yaml
+++ b/tests/mesh_shader_ext/mesh_shader_ext.task.hlsl.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/multi_entrypoint/multi_entrypoint.spv.yaml
+++ b/tests/multi_entrypoint/multi_entrypoint.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/push_constants/non_zero_block_offset.spv.yaml
+++ b/tests/push_constants/non_zero_block_offset.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_equal.cs.spv.yaml
+++ b/tests/raytrace/rayquery_equal.cs.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_ds.spv.yaml
+++ b/tests/raytrace/rayquery_init_ds.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_gs.spv.yaml
+++ b/tests/raytrace/rayquery_init_gs.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_hs.spv.yaml
+++ b/tests/raytrace/rayquery_init_hs.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_ps.spv.yaml
+++ b/tests/raytrace/rayquery_init_ps.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_rahit.spv.yaml
+++ b/tests/raytrace/rayquery_init_rahit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_rcall.spv.yaml
+++ b/tests/raytrace/rayquery_init_rcall.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_rchit.spv.yaml
+++ b/tests/raytrace/rayquery_init_rchit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_rgen.spv.yaml
+++ b/tests/raytrace/rayquery_init_rgen.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/rayquery_init_rmiss.spv.yaml
+++ b/tests/raytrace/rayquery_init_rmiss.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.acceleration-structure.spv.yaml
+++ b/tests/raytrace/raytracing.acceleration-structure.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/raytrace/raytracing.khr.closesthit.spv.yaml
+++ b/tests/raytrace/raytracing.khr.closesthit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.acceleration-structure.spv.yaml
+++ b/tests/raytrace/raytracing.nv.acceleration-structure.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/raytrace/raytracing.nv.anyhit.spv.yaml
+++ b/tests/raytrace/raytracing.nv.anyhit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.callable.spv.yaml
+++ b/tests/raytrace/raytracing.nv.callable.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.closesthit.spv.yaml
+++ b/tests/raytrace/raytracing.nv.closesthit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.enum.spv.yaml
+++ b/tests/raytrace/raytracing.nv.enum.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.intersection.spv.yaml
+++ b/tests/raytrace/raytracing.nv.intersection.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.library.spv.yaml
+++ b/tests/raytrace/raytracing.nv.library.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.miss.spv.yaml
+++ b/tests/raytrace/raytracing.nv.miss.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/raytrace/raytracing.nv.raygen.spv.yaml
+++ b/tests/raytrace/raytracing.nv.raygen.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spec_constants/basic.spv.yaml
+++ b/tests/spec_constants/basic.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spec_constants/convert.spv.yaml
+++ b/tests/spec_constants/convert.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spec_constants/local_size_id_10.spv.yaml
+++ b/tests/spec_constants/local_size_id_10.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/spec_constants/local_size_id_13.spv.yaml
+++ b/tests/spec_constants/local_size_id_13.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
 all_block_variables:

--- a/tests/spec_constants/ssbo_array.spv.yaml
+++ b/tests/spec_constants/ssbo_array.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spec_constants/test_32bit.spv.yaml
+++ b/tests/spec_constants/test_32bit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spec_constants/test_64bit.spv.yaml
+++ b/tests/spec_constants/test_64bit.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/spirv15/VertexShader.spv.yaml
+++ b/tests/spirv15/VertexShader.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/user_type/byte_address_buffer_0.spv.yaml
+++ b/tests/user_type/byte_address_buffer_0.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/user_type/byte_address_buffer_1.spv.yaml
+++ b/tests/user_type/byte_address_buffer_1.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/user_type/byte_address_buffer_2.spv.yaml
+++ b/tests/user_type/byte_address_buffer_2.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/user_type/byte_address_buffer_3.spv.yaml
+++ b/tests/user_type/byte_address_buffer_3.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/user_type/rw_byte_address_buffer.spv.yaml
+++ b/tests/user_type/rw_byte_address_buffer.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0

--- a/tests/variable_access/copy_memory.spv.yaml
+++ b/tests/variable_access/copy_memory.spv.yaml
@@ -1,4 +1,4 @@
-%YAML 1.0
+%YAML 1.1
 ---
 all_type_descriptions:
   - &td0


### PR DESCRIPTION
YAML 1.0 demands that the [separator between a YAML directive and its value is a colon](https://yaml.org/spec/1.0/#id2562252). This wasn't the case for the YAML files generated by spirv-reflect, as it used a space as separator instead. This resulted in tools parsing YAML stricly not being able to process the YAML files generated by spirv-reflect.

Newer YAML versions demand a [space as separator between YAML directive and its value](https://yaml.org/spec/1.1/#id895217) instead.

To fix this, this commit increases the YAML version to 1.1. This is done instead of replacing the separator to improve compatibility with tooling, as many tools don't support YAML 1.0 and require YAML 1.1 as minimal version (see the list of tools on https://yaml.org/).