### PR TITLE
Fix undefined enums

### DIFF
--- a/common/output_stream.cpp
+++ b/common/output_stream.cpp
@@ -204,7 +204,7 @@ std::string ToStringShaderStage(SpvReflectShaderStageFlagBits stage) {
   return "???";
 }
 
-std::string ToStringSpvStorageClass(SpvStorageClass storage_class) {
+std::string ToStringSpvStorageClass(int storage_class) {
   switch (storage_class) {
     case SpvStorageClassUniformConstant:
       return "UniformConstant";
@@ -343,7 +343,7 @@ std::string ToStringDescriptorType(SpvReflectDescriptorType value) {
   return "VK_DESCRIPTOR_TYPE_???";
 }
 
-static std::string ToStringSpvBuiltIn(SpvBuiltIn built_in) {
+static std::string ToStringSpvBuiltIn(int built_in) {
   switch (built_in) {
     case SpvBuiltInPosition:
       return "Position";

--- a/common/output_stream.h
+++ b/common/output_stream.h
@@ -9,7 +9,7 @@
 
 std::string ToStringSpvSourceLanguage(SpvSourceLanguage lang);
 std::string ToStringSpvExecutionModel(SpvExecutionModel model);
-std::string ToStringSpvStorageClass(SpvStorageClass storage_class);
+std::string ToStringSpvStorageClass(int storage_class);
 std::string ToStringSpvDim(SpvDim dim);
 std::string ToStringSpvBuiltIn(const SpvReflectInterfaceVariable& variable, bool preface);
 std::string ToStringSpvImageFormat(SpvImageFormat fmt);

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2188,7 +2188,8 @@ static SpvReflectResult ParseDescriptorBindings(SpvReflectPrvParser* p_parser, S
     // from the pointer so that we can use it to deduce deescriptor types.
     SpvStorageClass pointer_storage_class = SpvStorageClassMax;
     if (p_type->op == SpvOpTypePointer) {
-      pointer_storage_class = p_type->storage_class;
+      assert(p_type->storage_class != -1 && "Pointer types must have a valid storage class.");
+      pointer_storage_class = (SpvStorageClass)p_type->storage_class;
       // Find the type's node
       SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
       if (IsNull(p_type_node)) {

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -432,7 +432,7 @@ typedef struct SpvReflectInterfaceVariable {
   const char*                         semantic;
   SpvReflectDecorationFlags           decoration_flags;
   
-  // The builtin id if the variable is a builtin, and -1 otherwise.
+  // The builtin id (SpvBuiltIn) if the variable is a builtin, and -1 otherwise.
   int                                 built_in;
   SpvReflectNumericTraits             numeric;
   SpvReflectArrayTraits               array;

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -393,7 +393,7 @@ typedef struct SpvReflectTypeDescription {
   const char*                       type_name;
   // Non-NULL if type is member of a struct
   const char*                       struct_member_name;
-  SpvStorageClass                   storage_class;
+  int                               storage_class;
   SpvReflectTypeFlags               type_flags;
   SpvReflectDecorationFlags         decoration_flags;
 
@@ -429,7 +429,7 @@ typedef struct SpvReflectInterfaceVariable {
   SpvStorageClass                     storage_class;
   const char*                         semantic;
   SpvReflectDecorationFlags           decoration_flags;
-  SpvBuiltIn                          built_in;
+  int                                 built_in;
   SpvReflectNumericTraits             numeric;
   SpvReflectArrayTraits               array;
 

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -393,6 +393,9 @@ typedef struct SpvReflectTypeDescription {
   const char*                       type_name;
   // Non-NULL if type is member of a struct
   const char*                       struct_member_name;
+
+  // The storage class (SpvStorageClass) if the type, and -1 if it does not have a storage class.
+  // Note that SpvSt
   int                               storage_class;
   SpvReflectTypeFlags               type_flags;
   SpvReflectDecorationFlags         decoration_flags;

--- a/spirv_reflect.h
+++ b/spirv_reflect.h
@@ -395,7 +395,6 @@ typedef struct SpvReflectTypeDescription {
   const char*                       struct_member_name;
 
   // The storage class (SpvStorageClass) if the type, and -1 if it does not have a storage class.
-  // Note that SpvSt
   int                               storage_class;
   SpvReflectTypeFlags               type_flags;
   SpvReflectDecorationFlags         decoration_flags;
@@ -432,6 +431,8 @@ typedef struct SpvReflectInterfaceVariable {
   SpvStorageClass                     storage_class;
   const char*                         semantic;
   SpvReflectDecorationFlags           decoration_flags;
+  
+  // The builtin id if the variable is a builtin, and -1 otherwise.
   int                                 built_in;
   SpvReflectNumericTraits             numeric;
   SpvReflectArrayTraits               array;


### PR DESCRIPTION
There are a few places where an enum value is purpoposly getting a value
that is not one of the enum values. This is causing a problem when
testing. I have a quick fix to make those values `int` instead of the
enum type.

The variables could contain `-1` as a special value to indicate that no
storage class or builtin is used. We cannot change the enum class to add
`-1` because it is defined in spirv headers.
