### PR TITLE
Fixes issue #287 - fix crash

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -2549,7 +2549,7 @@ static SpvReflectResult ParseDescriptorBlockVariable(SpvReflectPrvParser* p_pars
           p_struct_type_description = FindType(p_module, p_member_type->id)->struct_type_description;
         }
         if (p_struct_type_description) {
-          uint32_t struct_id = FindType(p_module, p_member_type->id)->struct_type_description->id;
+          uint32_t struct_id = p_struct_type_description->id;
           p_parser->physical_pointer_structs[p_parser->physical_pointer_struct_count].struct_id = struct_id;
           p_parser->physical_pointer_structs[p_parser->physical_pointer_struct_count].p_var = p_member_var;
           p_parser->physical_pointer_struct_count++;


### PR DESCRIPTION
closes #287 - caused by assumption that PhysicalStorageBuffers will always point to structs.  They can point to plain data types.