### PR TITLE
Fix PushConstant padding to 16 bytes

### DIFF
--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -4016,7 +4016,7 @@ static SpvReflectResult ParsePushConstantBlocks(SpvReflectPrvParser* p_parser, S
     }
 
     p_push_constant->name = p_node->name;
-    result = ParseDescriptorBlockVariableSizes(p_parser, p_module, true, false, false, p_push_constant);
+    result = ParseDescriptorBlockVariableSizes(p_parser, p_module, true, false, true, p_push_constant);
     if (result != SPV_REFLECT_RESULT_SUCCESS) {
       return result;
     }

--- a/tests/glsl/buffer_handle_5.spv.yaml
+++ b/tests/glsl/buffer_handle_5.spv.yaml
@@ -164,7 +164,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000080 # NON_WRITABLE 
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/glsl/buffer_handle_7.spv.yaml
+++ b/tests/glsl/buffer_handle_7.spv.yaml
@@ -253,7 +253,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000080 # NON_WRITABLE 
     numeric:
       scalar: { width: 0, signedness: 0 }
@@ -285,7 +285,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }
@@ -301,8 +301,8 @@ all_block_variables:
     name: "params"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 8
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/glsl/buffer_handle_uvec2_pc.spv.yaml
+++ b/tests/glsl/buffer_handle_uvec2_pc.spv.yaml
@@ -42,7 +42,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -56,8 +56,8 @@ all_block_variables:
     name: "pc"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 8
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/glsl/buffer_pointer.spv.yaml
+++ b/tests/glsl/buffer_pointer.spv.yaml
@@ -194,7 +194,7 @@ all_block_variables:
     offset: 8
     absolute_offset: 8
     size: 4
-    padded_size: 8
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -209,7 +209,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }
@@ -226,8 +226,8 @@ all_block_variables:
     name: "push"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 8
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/hlsl/pushconstant.spv.yaml
+++ b/tests/hlsl/pushconstant.spv.yaml
@@ -125,7 +125,7 @@ all_block_variables:
     offset: 16
     absolute_offset: 16
     size: 8
-    padded_size: 16
+    padded_size: 8
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -139,8 +139,8 @@ all_block_variables:
     name: "g_PushConstants"
     offset: 0
     absolute_offset: 0
-    size: 32
-    padded_size: 32
+    size: 24
+    padded_size: 24
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/multi_entrypoint/multi_entrypoint.spv.yaml
+++ b/tests/multi_entrypoint/multi_entrypoint.spv.yaml
@@ -244,7 +244,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 4
-    padded_size: 16
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -258,8 +258,8 @@ all_block_variables:
     name: "push_constant_vert"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 4
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }
@@ -275,7 +275,7 @@ all_block_variables:
     offset: 0
     absolute_offset: 0
     size: 4
-    padded_size: 16
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -289,8 +289,8 @@ all_block_variables:
     name: "push_constant_frag"
     offset: 0
     absolute_offset: 0
-    size: 16
-    padded_size: 16
+    size: 4
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }

--- a/tests/push_constants/non_zero_block_offset.spv.yaml
+++ b/tests/push_constants/non_zero_block_offset.spv.yaml
@@ -182,7 +182,7 @@ all_block_variables:
     offset: 16
     absolute_offset: 16
     size: 4
-    padded_size: 16
+    padded_size: 4
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 32, signedness: 0 }
@@ -211,8 +211,8 @@ all_block_variables:
     name: "pc"
     offset: 4
     absolute_offset: 0
-    size: 32
-    padded_size: 32
+    size: 20
+    padded_size: 20
     decorations: 0x00000000 # NONE
     numeric:
       scalar: { width: 0, signedness: 0 }


### PR DESCRIPTION
This is just @danginsburg 's https://github.com/KhronosGroup/SPIRV-Reflect/pull/291 but with tests updated

Looked at the tests and they are now correct. We were having cases like

```
layout(push_constant, std430) uniform PerFrameData {
    uvec2 bufferId;
} pc;
```

showing `// size = 16, padded size = 16` when it should be `// size = 8, padded size = 8` as it is now