### PR TITLE
Add support for SpvOpTypeHitObjectEXT

### DIFF
--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -195,6 +195,7 @@ typedef enum SpvExecutionMode_ {
   SpvExecutionModeSampleInterlockUnorderedEXT = 5369,
   SpvExecutionModeShadingRateInterlockOrderedEXT = 5370,
   SpvExecutionModeShadingRateInterlockUnorderedEXT = 5371,
+  SpvExecutionModeShader64BitIndexingEXT = 5427,
   SpvExecutionModeSharedLocalMemorySizeINTEL = 5618,
   SpvExecutionModeRoundingModeRTPINTEL = 5620,
   SpvExecutionModeRoundingModeRTNINTEL = 5621,
@@ -249,8 +250,11 @@ typedef enum SpvStorageClass_ {
   SpvStorageClassPhysicalStorageBufferEXT = 5349,
   SpvStorageClassHitObjectAttributeNV = 5385,
   SpvStorageClassTaskPayloadWorkgroupEXT = 5402,
+  SpvStorageClassHitObjectAttributeEXT = 5411,
   SpvStorageClassCodeSectionINTEL = 5605,
+  SpvStorageClassDeviceOnlyALTERA = 5936,
   SpvStorageClassDeviceOnlyINTEL = 5936,
+  SpvStorageClassHostOnlyALTERA = 5937,
   SpvStorageClassHostOnlyINTEL = 5937,
   SpvStorageClassMax = 0x7fffffff,
 } SpvStorageClass;
@@ -489,6 +493,7 @@ typedef enum SpvFunctionParameterAttribute_ {
   SpvFunctionParameterAttributeNoCapture = 5,
   SpvFunctionParameterAttributeNoWrite = 6,
   SpvFunctionParameterAttributeNoReadWrite = 7,
+  SpvFunctionParameterAttributeRuntimeAlignedALTERA = 5940,
   SpvFunctionParameterAttributeRuntimeAlignedINTEL = 5940,
   SpvFunctionParameterAttributeMax = 0x7fffffff,
 } SpvFunctionParameterAttribute;
@@ -556,6 +561,8 @@ typedef enum SpvDecoration_ {
   SpvDecorationPayloadNodeSparseArrayAMDX = 5099,
   SpvDecorationPayloadNodeArraySizeAMDX = 5100,
   SpvDecorationPayloadDispatchIndirectAMDX = 5105,
+  SpvDecorationArrayStrideIdEXT = 5124,
+  SpvDecorationOffsetIdEXT = 5125,
   SpvDecorationOverrideCoverageNV = 5248,
   SpvDecorationPassthroughNV = 5250,
   SpvDecorationViewportRelativeNV = 5252,
@@ -572,7 +579,10 @@ typedef enum SpvDecoration_ {
   SpvDecorationRestrictPointerEXT = 5355,
   SpvDecorationAliasedPointer = 5356,
   SpvDecorationAliasedPointerEXT = 5356,
+  SpvDecorationMemberOffsetNV = 5358,
   SpvDecorationHitObjectShaderRecordBufferNV = 5386,
+  SpvDecorationHitObjectShaderRecordBufferEXT = 5389,
+  SpvDecorationBankNV = 5397,
   SpvDecorationBindlessSamplerNV = 5398,
   SpvDecorationBindlessImageNV = 5399,
   SpvDecorationBoundSamplerNV = 5400,
@@ -593,54 +603,95 @@ typedef enum SpvDecoration_ {
   SpvDecorationUserTypeGOOGLE = 5636,
   SpvDecorationFunctionRoundingModeINTEL = 5822,
   SpvDecorationFunctionDenormModeINTEL = 5823,
+  SpvDecorationRegisterALTERA = 5825,
   SpvDecorationRegisterINTEL = 5825,
+  SpvDecorationMemoryALTERA = 5826,
   SpvDecorationMemoryINTEL = 5826,
+  SpvDecorationNumbanksALTERA = 5827,
   SpvDecorationNumbanksINTEL = 5827,
+  SpvDecorationBankwidthALTERA = 5828,
   SpvDecorationBankwidthINTEL = 5828,
+  SpvDecorationMaxPrivateCopiesALTERA = 5829,
   SpvDecorationMaxPrivateCopiesINTEL = 5829,
+  SpvDecorationSinglepumpALTERA = 5830,
   SpvDecorationSinglepumpINTEL = 5830,
+  SpvDecorationDoublepumpALTERA = 5831,
   SpvDecorationDoublepumpINTEL = 5831,
+  SpvDecorationMaxReplicatesALTERA = 5832,
   SpvDecorationMaxReplicatesINTEL = 5832,
+  SpvDecorationSimpleDualPortALTERA = 5833,
   SpvDecorationSimpleDualPortINTEL = 5833,
+  SpvDecorationMergeALTERA = 5834,
   SpvDecorationMergeINTEL = 5834,
+  SpvDecorationBankBitsALTERA = 5835,
   SpvDecorationBankBitsINTEL = 5835,
+  SpvDecorationForcePow2DepthALTERA = 5836,
   SpvDecorationForcePow2DepthINTEL = 5836,
+  SpvDecorationStridesizeALTERA = 5883,
   SpvDecorationStridesizeINTEL = 5883,
+  SpvDecorationWordsizeALTERA = 5884,
   SpvDecorationWordsizeINTEL = 5884,
+  SpvDecorationTrueDualPortALTERA = 5885,
   SpvDecorationTrueDualPortINTEL = 5885,
+  SpvDecorationBurstCoalesceALTERA = 5899,
   SpvDecorationBurstCoalesceINTEL = 5899,
+  SpvDecorationCacheSizeALTERA = 5900,
   SpvDecorationCacheSizeINTEL = 5900,
+  SpvDecorationDontStaticallyCoalesceALTERA = 5901,
   SpvDecorationDontStaticallyCoalesceINTEL = 5901,
+  SpvDecorationPrefetchALTERA = 5902,
   SpvDecorationPrefetchINTEL = 5902,
+  SpvDecorationStallEnableALTERA = 5905,
   SpvDecorationStallEnableINTEL = 5905,
+  SpvDecorationFuseLoopsInFunctionALTERA = 5907,
   SpvDecorationFuseLoopsInFunctionINTEL = 5907,
+  SpvDecorationMathOpDSPModeALTERA = 5909,
   SpvDecorationMathOpDSPModeINTEL = 5909,
   SpvDecorationAliasScopeINTEL = 5914,
   SpvDecorationNoAliasINTEL = 5915,
+  SpvDecorationInitiationIntervalALTERA = 5917,
   SpvDecorationInitiationIntervalINTEL = 5917,
+  SpvDecorationMaxConcurrencyALTERA = 5918,
   SpvDecorationMaxConcurrencyINTEL = 5918,
+  SpvDecorationPipelineEnableALTERA = 5919,
   SpvDecorationPipelineEnableINTEL = 5919,
+  SpvDecorationBufferLocationALTERA = 5921,
   SpvDecorationBufferLocationINTEL = 5921,
+  SpvDecorationIOPipeStorageALTERA = 5944,
   SpvDecorationIOPipeStorageINTEL = 5944,
   SpvDecorationFunctionFloatingPointModeINTEL = 6080,
   SpvDecorationSingleElementVectorINTEL = 6085,
   SpvDecorationVectorComputeCallableFunctionINTEL = 6087,
   SpvDecorationMediaBlockIOINTEL = 6140,
+  SpvDecorationStallFreeALTERA = 6151,
   SpvDecorationStallFreeINTEL = 6151,
   SpvDecorationFPMaxErrorDecorationINTEL = 6170,
+  SpvDecorationLatencyControlLabelALTERA = 6172,
   SpvDecorationLatencyControlLabelINTEL = 6172,
+  SpvDecorationLatencyControlConstraintALTERA = 6173,
   SpvDecorationLatencyControlConstraintINTEL = 6173,
+  SpvDecorationConduitKernelArgumentALTERA = 6175,
   SpvDecorationConduitKernelArgumentINTEL = 6175,
+  SpvDecorationRegisterMapKernelArgumentALTERA = 6176,
   SpvDecorationRegisterMapKernelArgumentINTEL = 6176,
+  SpvDecorationMMHostInterfaceAddressWidthALTERA = 6177,
   SpvDecorationMMHostInterfaceAddressWidthINTEL = 6177,
+  SpvDecorationMMHostInterfaceDataWidthALTERA = 6178,
   SpvDecorationMMHostInterfaceDataWidthINTEL = 6178,
+  SpvDecorationMMHostInterfaceLatencyALTERA = 6179,
   SpvDecorationMMHostInterfaceLatencyINTEL = 6179,
+  SpvDecorationMMHostInterfaceReadWriteModeALTERA = 6180,
   SpvDecorationMMHostInterfaceReadWriteModeINTEL = 6180,
+  SpvDecorationMMHostInterfaceMaxBurstALTERA = 6181,
   SpvDecorationMMHostInterfaceMaxBurstINTEL = 6181,
+  SpvDecorationMMHostInterfaceWaitRequestALTERA = 6182,
   SpvDecorationMMHostInterfaceWaitRequestINTEL = 6182,
+  SpvDecorationStableKernelArgumentALTERA = 6183,
   SpvDecorationStableKernelArgumentINTEL = 6183,
   SpvDecorationHostAccessINTEL = 6188,
+  SpvDecorationInitModeALTERA = 6190,
   SpvDecorationInitModeINTEL = 6190,
+  SpvDecorationImplementInRegisterMapALTERA = 6191,
   SpvDecorationImplementInRegisterMapINTEL = 6191,
   SpvDecorationConditionalINTEL = 6247,
   SpvDecorationCacheControlLoadINTEL = 6442,
@@ -725,6 +776,8 @@ typedef enum SpvBuiltIn_ {
   SpvBuiltInFragStencilRefEXT = 5014,
   SpvBuiltInRemainingRecursionLevelsAMDX = 5021,
   SpvBuiltInShaderIndexAMDX = 5073,
+  SpvBuiltInSamplerHeapEXT = 5122,
+  SpvBuiltInResourceHeapEXT = 5123,
   SpvBuiltInViewportMaskNV = 5253,
   SpvBuiltInSecondaryPositionNV = 5257,
   SpvBuiltInSecondaryViewportMaskNV = 5258,
@@ -822,15 +875,25 @@ typedef enum SpvLoopControlShift_ {
   SpvLoopControlIterationMultipleShift = 6,
   SpvLoopControlPeelCountShift = 7,
   SpvLoopControlPartialCountShift = 8,
+  SpvLoopControlInitiationIntervalALTERAShift = 16,
   SpvLoopControlInitiationIntervalINTELShift = 16,
+  SpvLoopControlMaxConcurrencyALTERAShift = 17,
   SpvLoopControlMaxConcurrencyINTELShift = 17,
+  SpvLoopControlDependencyArrayALTERAShift = 18,
   SpvLoopControlDependencyArrayINTELShift = 18,
+  SpvLoopControlPipelineEnableALTERAShift = 19,
   SpvLoopControlPipelineEnableINTELShift = 19,
+  SpvLoopControlLoopCoalesceALTERAShift = 20,
   SpvLoopControlLoopCoalesceINTELShift = 20,
+  SpvLoopControlMaxInterleavingALTERAShift = 21,
   SpvLoopControlMaxInterleavingINTELShift = 21,
+  SpvLoopControlSpeculatedIterationsALTERAShift = 22,
   SpvLoopControlSpeculatedIterationsINTELShift = 22,
+  SpvLoopControlNoFusionALTERAShift = 23,
   SpvLoopControlNoFusionINTELShift = 23,
+  SpvLoopControlLoopCountALTERAShift = 24,
   SpvLoopControlLoopCountINTELShift = 24,
+  SpvLoopControlMaxReinvocationDelayALTERAShift = 25,
   SpvLoopControlMaxReinvocationDelayINTELShift = 25,
   SpvLoopControlMax = 0x7fffffff,
 } SpvLoopControlShift;
@@ -846,15 +909,25 @@ typedef enum SpvLoopControlMask_ {
   SpvLoopControlIterationMultipleMask = 0x00000040,
   SpvLoopControlPeelCountMask = 0x00000080,
   SpvLoopControlPartialCountMask = 0x00000100,
+  SpvLoopControlInitiationIntervalALTERAMask = 0x00010000,
   SpvLoopControlInitiationIntervalINTELMask = 0x00010000,
+  SpvLoopControlMaxConcurrencyALTERAMask = 0x00020000,
   SpvLoopControlMaxConcurrencyINTELMask = 0x00020000,
+  SpvLoopControlDependencyArrayALTERAMask = 0x00040000,
   SpvLoopControlDependencyArrayINTELMask = 0x00040000,
+  SpvLoopControlPipelineEnableALTERAMask = 0x00080000,
   SpvLoopControlPipelineEnableINTELMask = 0x00080000,
+  SpvLoopControlLoopCoalesceALTERAMask = 0x00100000,
   SpvLoopControlLoopCoalesceINTELMask = 0x00100000,
+  SpvLoopControlMaxInterleavingALTERAMask = 0x00200000,
   SpvLoopControlMaxInterleavingINTELMask = 0x00200000,
+  SpvLoopControlSpeculatedIterationsALTERAMask = 0x00400000,
   SpvLoopControlSpeculatedIterationsINTELMask = 0x00400000,
+  SpvLoopControlNoFusionALTERAMask = 0x00800000,
   SpvLoopControlNoFusionINTELMask = 0x00800000,
+  SpvLoopControlLoopCountALTERAMask = 0x01000000,
   SpvLoopControlLoopCountINTELMask = 0x01000000,
+  SpvLoopControlMaxReinvocationDelayALTERAMask = 0x02000000,
   SpvLoopControlMaxReinvocationDelayINTELMask = 0x02000000,
 } SpvLoopControlMask;
 
@@ -967,8 +1040,11 @@ typedef enum SpvGroupOperation_ {
   SpvGroupOperationInclusiveScan = 1,
   SpvGroupOperationExclusiveScan = 2,
   SpvGroupOperationClusteredReduce = 3,
+  SpvGroupOperationPartitionedReduceEXT = 6,
   SpvGroupOperationPartitionedReduceNV = 6,
+  SpvGroupOperationPartitionedInclusiveScanEXT = 7,
   SpvGroupOperationPartitionedInclusiveScanNV = 7,
+  SpvGroupOperationPartitionedExclusiveScanEXT = 8,
   SpvGroupOperationPartitionedExclusiveScanNV = 8,
   SpvGroupOperationMax = 0x7fffffff,
 } SpvGroupOperation;
@@ -1124,6 +1200,7 @@ typedef enum SpvCapability_ {
   SpvCapabilityBFloat16TypeKHR = 5116,
   SpvCapabilityBFloat16DotProductKHR = 5117,
   SpvCapabilityBFloat16CooperativeMatrixKHR = 5118,
+  SpvCapabilityDescriptorHeapEXT = 5128,
   SpvCapabilitySampleMaskOverrideCoverageNV = 5249,
   SpvCapabilityGeometryShaderPassthroughNV = 5251,
   SpvCapabilityShaderViewportIndexLayerEXT = 5254,
@@ -1141,6 +1218,7 @@ typedef enum SpvCapability_ {
   SpvCapabilityComputeDerivativeGroupQuadsNV = 5288,
   SpvCapabilityFragmentDensityEXT = 5291,
   SpvCapabilityShadingRateNV = 5291,
+  SpvCapabilityGroupNonUniformPartitionedEXT = 5297,
   SpvCapabilityGroupNonUniformPartitionedNV = 5297,
   SpvCapabilityShaderNonUniform = 5301,
   SpvCapabilityShaderNonUniformEXT = 5301,
@@ -1188,6 +1266,7 @@ typedef enum SpvCapability_ {
   SpvCapabilityDisplacementMicromapNV = 5380,
   SpvCapabilityRayTracingOpacityMicromapEXT = 5381,
   SpvCapabilityShaderInvocationReorderNV = 5383,
+  SpvCapabilityShaderInvocationReorderEXT = 5388,
   SpvCapabilityBindlessTextureNV = 5390,
   SpvCapabilityRayQueryPositionFetchKHR = 5391,
   SpvCapabilityCooperativeVectorNV = 5394,
@@ -1196,6 +1275,9 @@ typedef enum SpvCapability_ {
   SpvCapabilityRawAccessChainsNV = 5414,
   SpvCapabilityRayTracingSpheresGeometryNV = 5418,
   SpvCapabilityRayTracingLinearSweptSpheresGeometryNV = 5419,
+  SpvCapabilityPushConstantBanksNV = 5423,
+  SpvCapabilityLongVectorEXT = 5425,
+  SpvCapabilityShader64BitIndexingEXT = 5426,
   SpvCapabilityCooperativeMatrixReductionsNV = 5430,
   SpvCapabilityCooperativeMatrixConversionsNV = 5431,
   SpvCapabilityCooperativeMatrixPerElementOperationsNV = 5432,
@@ -1225,26 +1307,42 @@ typedef enum SpvCapability_ {
   SpvCapabilitySubgroupAvcMotionEstimationChromaINTEL = 5698,
   SpvCapabilityVariableLengthArrayINTEL = 5817,
   SpvCapabilityFunctionFloatControlINTEL = 5821,
+  SpvCapabilityFPGAMemoryAttributesALTERA = 5824,
   SpvCapabilityFPGAMemoryAttributesINTEL = 5824,
   SpvCapabilityFPFastMathModeINTEL = 5837,
+  SpvCapabilityArbitraryPrecisionIntegersALTERA = 5844,
   SpvCapabilityArbitraryPrecisionIntegersINTEL = 5844,
+  SpvCapabilityArbitraryPrecisionFloatingPointALTERA = 5845,
   SpvCapabilityArbitraryPrecisionFloatingPointINTEL = 5845,
   SpvCapabilityUnstructuredLoopControlsINTEL = 5886,
+  SpvCapabilityFPGALoopControlsALTERA = 5888,
   SpvCapabilityFPGALoopControlsINTEL = 5888,
   SpvCapabilityKernelAttributesINTEL = 5892,
   SpvCapabilityFPGAKernelAttributesINTEL = 5897,
+  SpvCapabilityFPGAMemoryAccessesALTERA = 5898,
   SpvCapabilityFPGAMemoryAccessesINTEL = 5898,
+  SpvCapabilityFPGAClusterAttributesALTERA = 5904,
   SpvCapabilityFPGAClusterAttributesINTEL = 5904,
+  SpvCapabilityLoopFuseALTERA = 5906,
   SpvCapabilityLoopFuseINTEL = 5906,
+  SpvCapabilityFPGADSPControlALTERA = 5908,
   SpvCapabilityFPGADSPControlINTEL = 5908,
   SpvCapabilityMemoryAccessAliasingINTEL = 5910,
+  SpvCapabilityFPGAInvocationPipeliningAttributesALTERA = 5916,
   SpvCapabilityFPGAInvocationPipeliningAttributesINTEL = 5916,
+  SpvCapabilityFPGABufferLocationALTERA = 5920,
   SpvCapabilityFPGABufferLocationINTEL = 5920,
+  SpvCapabilityArbitraryPrecisionFixedPointALTERA = 5922,
   SpvCapabilityArbitraryPrecisionFixedPointINTEL = 5922,
+  SpvCapabilityUSMStorageClassesALTERA = 5935,
   SpvCapabilityUSMStorageClassesINTEL = 5935,
+  SpvCapabilityRuntimeAlignedAttributeALTERA = 5939,
   SpvCapabilityRuntimeAlignedAttributeINTEL = 5939,
+  SpvCapabilityIOPipesALTERA = 5943,
   SpvCapabilityIOPipesINTEL = 5943,
+  SpvCapabilityBlockingPipesALTERA = 5945,
   SpvCapabilityBlockingPipesINTEL = 5945,
+  SpvCapabilityFPGARegALTERA = 5948,
   SpvCapabilityFPGARegINTEL = 5948,
   SpvCapabilityDotProductInputAll = 6016,
   SpvCapabilityDotProductInputAllKHR = 6016,
@@ -1260,6 +1358,7 @@ typedef enum SpvCapability_ {
   SpvCapabilityBitInstructions = 6025,
   SpvCapabilityGroupNonUniformRotateKHR = 6026,
   SpvCapabilityFloatControls2 = 6029,
+  SpvCapabilityFMAKHR = 6030,
   SpvCapabilityAtomicFloat32AddEXT = 6033,
   SpvCapabilityAtomicFloat64AddEXT = 6034,
   SpvCapabilityLongCompositesINTEL = 6089,
@@ -1270,13 +1369,18 @@ typedef enum SpvCapability_ {
   SpvCapabilityBFloat16ConversionINTEL = 6115,
   SpvCapabilitySplitBarrierINTEL = 6141,
   SpvCapabilityArithmeticFenceEXT = 6144,
+  SpvCapabilityFPGAClusterAttributesV2ALTERA = 6150,
   SpvCapabilityFPGAClusterAttributesV2INTEL = 6150,
   SpvCapabilityFPGAKernelAttributesv2INTEL = 6161,
+  SpvCapabilityTaskSequenceALTERA = 6162,
   SpvCapabilityTaskSequenceINTEL = 6162,
   SpvCapabilityFPMaxErrorINTEL = 6169,
+  SpvCapabilityFPGALatencyControlALTERA = 6171,
   SpvCapabilityFPGALatencyControlINTEL = 6171,
+  SpvCapabilityFPGAArgumentInterfacesALTERA = 6174,
   SpvCapabilityFPGAArgumentInterfacesINTEL = 6174,
   SpvCapabilityGlobalVariableHostAccessINTEL = 6187,
+  SpvCapabilityGlobalVariableFPGADecorationsALTERA = 6189,
   SpvCapabilityGlobalVariableFPGADecorationsINTEL = 6189,
   SpvCapabilitySubgroupBufferPrefetchINTEL = 6220,
   SpvCapabilitySubgroup2DBlockIOINTEL = 6228,
@@ -1488,7 +1592,9 @@ typedef enum SpvTensorOperandsMask_ {
 } SpvTensorOperandsMask;
 
 typedef enum SpvInitializationModeQualifier_ {
+  SpvInitializationModeQualifierInitOnDeviceReprogramALTERA = 0,
   SpvInitializationModeQualifierInitOnDeviceReprogramINTEL = 0,
+  SpvInitializationModeQualifierInitOnDeviceResetALTERA = 1,
   SpvInitializationModeQualifierInitOnDeviceResetINTEL = 1,
   SpvInitializationModeQualifierMax = 0x7fffffff,
 } SpvInitializationModeQualifier;
@@ -1975,6 +2081,7 @@ typedef enum SpvOp_ {
   SpvOpUntypedInBoundsPtrAccessChainKHR = 4424,
   SpvOpUntypedArrayLengthKHR = 4425,
   SpvOpUntypedPrefetchKHR = 4426,
+  SpvOpFmaKHR = 4427,
   SpvOpSubgroupAllKHR = 4428,
   SpvOpSubgroupAnyKHR = 4429,
   SpvOpSubgroupAllEqualKHR = 4430,
@@ -2047,6 +2154,11 @@ typedef enum SpvOp_ {
   SpvOpSpecConstantStringAMDX = 5104,
   SpvOpGroupNonUniformQuadAllKHR = 5110,
   SpvOpGroupNonUniformQuadAnyKHR = 5111,
+  SpvOpTypeBufferEXT = 5115,
+  SpvOpBufferPointerEXT = 5119,
+  SpvOpUntypedImageTexelPointerEXT = 5126,
+  SpvOpMemberDecorateIdEXT = 5127,
+  SpvOpConstantSizeOfEXT = 5129,
   SpvOpHitObjectRecordHitMotionNV = 5249,
   SpvOpHitObjectRecordHitWithIndexMotionNV = 5250,
   SpvOpHitObjectRecordMissMotionNV = 5251,
@@ -2082,6 +2194,7 @@ typedef enum SpvOp_ {
   SpvOpTypeHitObjectNV = 5281,
   SpvOpImageSampleFootprintNV = 5283,
   SpvOpTypeCooperativeVectorNV = 5288,
+  SpvOpTypeVectorIdEXT = 5288,
   SpvOpCooperativeVectorMatrixMulNV = 5289,
   SpvOpCooperativeVectorOuterProductAccumulateNV = 5290,
   SpvOpCooperativeVectorReduceSumAccumulateNV = 5291,
@@ -2089,12 +2202,43 @@ typedef enum SpvOp_ {
   SpvOpCooperativeMatrixConvertNV = 5293,
   SpvOpEmitMeshTasksEXT = 5294,
   SpvOpSetMeshOutputsEXT = 5295,
+  SpvOpGroupNonUniformPartitionEXT = 5296,
   SpvOpGroupNonUniformPartitionNV = 5296,
   SpvOpWritePackedPrimitiveIndices4x8NV = 5299,
   SpvOpFetchMicroTriangleVertexPositionNV = 5300,
   SpvOpFetchMicroTriangleVertexBarycentricNV = 5301,
   SpvOpCooperativeVectorLoadNV = 5302,
   SpvOpCooperativeVectorStoreNV = 5303,
+  SpvOpHitObjectRecordFromQueryEXT = 5304,
+  SpvOpHitObjectRecordMissEXT = 5305,
+  SpvOpHitObjectRecordMissMotionEXT = 5306,
+  SpvOpHitObjectGetIntersectionTriangleVertexPositionsEXT = 5307,
+  SpvOpHitObjectGetRayFlagsEXT = 5308,
+  SpvOpHitObjectSetShaderBindingTableRecordIndexEXT = 5309,
+  SpvOpHitObjectReorderExecuteShaderEXT = 5310,
+  SpvOpHitObjectTraceReorderExecuteEXT = 5311,
+  SpvOpHitObjectTraceMotionReorderExecuteEXT = 5312,
+  SpvOpTypeHitObjectEXT = 5313,
+  SpvOpReorderThreadWithHintEXT = 5314,
+  SpvOpReorderThreadWithHitObjectEXT = 5315,
+  SpvOpHitObjectTraceRayEXT = 5316,
+  SpvOpHitObjectTraceRayMotionEXT = 5317,
+  SpvOpHitObjectRecordEmptyEXT = 5318,
+  SpvOpHitObjectExecuteShaderEXT = 5319,
+  SpvOpHitObjectGetCurrentTimeEXT = 5320,
+  SpvOpHitObjectGetAttributesEXT = 5321,
+  SpvOpHitObjectGetHitKindEXT = 5322,
+  SpvOpHitObjectGetPrimitiveIndexEXT = 5323,
+  SpvOpHitObjectGetGeometryIndexEXT = 5324,
+  SpvOpHitObjectGetInstanceIdEXT = 5325,
+  SpvOpHitObjectGetInstanceCustomIndexEXT = 5326,
+  SpvOpHitObjectGetObjectRayOriginEXT = 5327,
+  SpvOpHitObjectGetObjectRayDirectionEXT = 5328,
+  SpvOpHitObjectGetWorldRayDirectionEXT = 5329,
+  SpvOpHitObjectGetWorldRayOriginEXT = 5330,
+  SpvOpHitObjectGetObjectToWorldEXT = 5331,
+  SpvOpHitObjectGetWorldToObjectEXT = 5332,
+  SpvOpHitObjectGetRayTMaxEXT = 5333,
   SpvOpReportIntersectionKHR = 5334,
   SpvOpReportIntersectionNV = 5334,
   SpvOpIgnoreIntersectionNV = 5335,
@@ -2109,6 +2253,12 @@ typedef enum SpvOp_ {
   SpvOpRayQueryGetClusterIdNV = 5345,
   SpvOpRayQueryGetIntersectionClusterIdNV = 5345,
   SpvOpHitObjectGetClusterIdNV = 5346,
+  SpvOpHitObjectGetRayTMinEXT = 5347,
+  SpvOpHitObjectGetShaderBindingTableRecordIndexEXT = 5348,
+  SpvOpHitObjectGetShaderRecordBufferHandleEXT = 5349,
+  SpvOpHitObjectIsEmptyEXT = 5350,
+  SpvOpHitObjectIsHitEXT = 5351,
+  SpvOpHitObjectIsMissEXT = 5352,
   SpvOpTypeCooperativeMatrixNV = 5358,
   SpvOpCooperativeMatrixLoadNV = 5359,
   SpvOpCooperativeMatrixStoreNV = 5360,
@@ -2315,23 +2465,41 @@ typedef enum SpvOp_ {
   SpvOpVariableLengthArrayINTEL = 5818,
   SpvOpSaveMemoryINTEL = 5819,
   SpvOpRestoreMemoryINTEL = 5820,
+  SpvOpArbitraryFloatSinCosPiALTERA = 5840,
   SpvOpArbitraryFloatSinCosPiINTEL = 5840,
+  SpvOpArbitraryFloatCastALTERA = 5841,
   SpvOpArbitraryFloatCastINTEL = 5841,
+  SpvOpArbitraryFloatCastFromIntALTERA = 5842,
   SpvOpArbitraryFloatCastFromIntINTEL = 5842,
+  SpvOpArbitraryFloatCastToIntALTERA = 5843,
   SpvOpArbitraryFloatCastToIntINTEL = 5843,
+  SpvOpArbitraryFloatAddALTERA = 5846,
   SpvOpArbitraryFloatAddINTEL = 5846,
+  SpvOpArbitraryFloatSubALTERA = 5847,
   SpvOpArbitraryFloatSubINTEL = 5847,
+  SpvOpArbitraryFloatMulALTERA = 5848,
   SpvOpArbitraryFloatMulINTEL = 5848,
+  SpvOpArbitraryFloatDivALTERA = 5849,
   SpvOpArbitraryFloatDivINTEL = 5849,
+  SpvOpArbitraryFloatGTALTERA = 5850,
   SpvOpArbitraryFloatGTINTEL = 5850,
+  SpvOpArbitraryFloatGEALTERA = 5851,
   SpvOpArbitraryFloatGEINTEL = 5851,
+  SpvOpArbitraryFloatLTALTERA = 5852,
   SpvOpArbitraryFloatLTINTEL = 5852,
+  SpvOpArbitraryFloatLEALTERA = 5853,
   SpvOpArbitraryFloatLEINTEL = 5853,
+  SpvOpArbitraryFloatEQALTERA = 5854,
   SpvOpArbitraryFloatEQINTEL = 5854,
+  SpvOpArbitraryFloatRecipALTERA = 5855,
   SpvOpArbitraryFloatRecipINTEL = 5855,
+  SpvOpArbitraryFloatRSqrtALTERA = 5856,
   SpvOpArbitraryFloatRSqrtINTEL = 5856,
+  SpvOpArbitraryFloatCbrtALTERA = 5857,
   SpvOpArbitraryFloatCbrtINTEL = 5857,
+  SpvOpArbitraryFloatHypotALTERA = 5858,
   SpvOpArbitraryFloatHypotINTEL = 5858,
+  SpvOpArbitraryFloatSqrtALTERA = 5859,
   SpvOpArbitraryFloatSqrtINTEL = 5859,
   SpvOpArbitraryFloatLogINTEL = 5860,
   SpvOpArbitraryFloatLog2INTEL = 5861,
@@ -2360,21 +2528,37 @@ typedef enum SpvOp_ {
   SpvOpAliasDomainDeclINTEL = 5911,
   SpvOpAliasScopeDeclINTEL = 5912,
   SpvOpAliasScopeListDeclINTEL = 5913,
+  SpvOpFixedSqrtALTERA = 5923,
   SpvOpFixedSqrtINTEL = 5923,
+  SpvOpFixedRecipALTERA = 5924,
   SpvOpFixedRecipINTEL = 5924,
+  SpvOpFixedRsqrtALTERA = 5925,
   SpvOpFixedRsqrtINTEL = 5925,
+  SpvOpFixedSinALTERA = 5926,
   SpvOpFixedSinINTEL = 5926,
+  SpvOpFixedCosALTERA = 5927,
   SpvOpFixedCosINTEL = 5927,
+  SpvOpFixedSinCosALTERA = 5928,
   SpvOpFixedSinCosINTEL = 5928,
+  SpvOpFixedSinPiALTERA = 5929,
   SpvOpFixedSinPiINTEL = 5929,
+  SpvOpFixedCosPiALTERA = 5930,
   SpvOpFixedCosPiINTEL = 5930,
+  SpvOpFixedSinCosPiALTERA = 5931,
   SpvOpFixedSinCosPiINTEL = 5931,
+  SpvOpFixedLogALTERA = 5932,
   SpvOpFixedLogINTEL = 5932,
+  SpvOpFixedExpALTERA = 5933,
   SpvOpFixedExpINTEL = 5933,
+  SpvOpPtrCastToCrossWorkgroupALTERA = 5934,
   SpvOpPtrCastToCrossWorkgroupINTEL = 5934,
+  SpvOpCrossWorkgroupCastToPtrALTERA = 5938,
   SpvOpCrossWorkgroupCastToPtrINTEL = 5938,
+  SpvOpReadPipeBlockingALTERA = 5946,
   SpvOpReadPipeBlockingINTEL = 5946,
+  SpvOpWritePipeBlockingALTERA = 5947,
   SpvOpWritePipeBlockingINTEL = 5947,
+  SpvOpFPGARegALTERA = 5949,
   SpvOpFPGARegINTEL = 5949,
   SpvOpRayQueryGetRayTMinKHR = 6016,
   SpvOpRayQueryGetRayFlagsKHR = 6017,
@@ -2404,10 +2588,15 @@ typedef enum SpvOp_ {
   SpvOpControlBarrierArriveINTEL = 6142,
   SpvOpControlBarrierWaitINTEL = 6143,
   SpvOpArithmeticFenceEXT = 6145,
+  SpvOpTaskSequenceCreateALTERA = 6163,
   SpvOpTaskSequenceCreateINTEL = 6163,
+  SpvOpTaskSequenceAsyncALTERA = 6164,
   SpvOpTaskSequenceAsyncINTEL = 6164,
+  SpvOpTaskSequenceGetALTERA = 6165,
   SpvOpTaskSequenceGetINTEL = 6165,
+  SpvOpTaskSequenceReleaseALTERA = 6166,
   SpvOpTaskSequenceReleaseINTEL = 6166,
+  SpvOpTypeTaskSequenceALTERA = 6199,
   SpvOpTypeTaskSequenceINTEL = 6199,
   SpvOpSubgroupBlockPrefetchINTEL = 6221,
   SpvOpSubgroup2DBlockLoadINTEL = 6231,
@@ -3927,6 +4116,10 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = false;
       *hasResultType = false;
       break;
+    case SpvOpFmaKHR:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
     case SpvOpSubgroupAllKHR:
       *hasResult = true;
       *hasResultType = true;
@@ -4191,6 +4384,26 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = true;
       *hasResultType = true;
       break;
+    case SpvOpTypeBufferEXT:
+      *hasResult = true;
+      *hasResultType = false;
+      break;
+    case SpvOpBufferPointerEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpUntypedImageTexelPointerEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpMemberDecorateIdEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpConstantSizeOfEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
     case SpvOpHitObjectRecordHitMotionNV:
       *hasResult = false;
       *hasResultType = false;
@@ -4327,7 +4540,7 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpTypeCooperativeVectorNV:
+    case SpvOpTypeVectorIdEXT:
       *hasResult = true;
       *hasResultType = false;
       break;
@@ -4359,7 +4572,7 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = false;
       *hasResultType = false;
       break;
-    case SpvOpGroupNonUniformPartitionNV:
+    case SpvOpGroupNonUniformPartitionEXT:
       *hasResult = true;
       *hasResultType = true;
       break;
@@ -4382,6 +4595,126 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
     case SpvOpCooperativeVectorStoreNV:
       *hasResult = false;
       *hasResultType = false;
+      break;
+    case SpvOpHitObjectRecordFromQueryEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectRecordMissEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectRecordMissMotionEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectGetIntersectionTriangleVertexPositionsEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetRayFlagsEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectSetShaderBindingTableRecordIndexEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectReorderExecuteShaderEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectTraceReorderExecuteEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectTraceMotionReorderExecuteEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpTypeHitObjectEXT:
+      *hasResult = true;
+      *hasResultType = false;
+      break;
+    case SpvOpReorderThreadWithHintEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpReorderThreadWithHitObjectEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectTraceRayEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectTraceRayMotionEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectRecordEmptyEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectExecuteShaderEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectGetCurrentTimeEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetAttributesEXT:
+      *hasResult = false;
+      *hasResultType = false;
+      break;
+    case SpvOpHitObjectGetHitKindEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetPrimitiveIndexEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetGeometryIndexEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetInstanceIdEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetInstanceCustomIndexEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetObjectRayOriginEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetObjectRayDirectionEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetWorldRayDirectionEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetWorldRayOriginEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetObjectToWorldEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetWorldToObjectEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetRayTMaxEXT:
+      *hasResult = true;
+      *hasResultType = true;
       break;
     case SpvOpReportIntersectionKHR:
       *hasResult = true;
@@ -4424,6 +4757,30 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResultType = true;
       break;
     case SpvOpHitObjectGetClusterIdNV:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetRayTMinEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetShaderBindingTableRecordIndexEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectGetShaderRecordBufferHandleEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectIsEmptyEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectIsHitEXT:
+      *hasResult = true;
+      *hasResultType = true;
+      break;
+    case SpvOpHitObjectIsMissEXT:
       *hasResult = true;
       *hasResultType = true;
       break;
@@ -5239,75 +5596,75 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = false;
       *hasResultType = false;
       break;
-    case SpvOpArbitraryFloatSinCosPiINTEL:
+    case SpvOpArbitraryFloatSinCosPiALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatCastINTEL:
+    case SpvOpArbitraryFloatCastALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatCastFromIntINTEL:
+    case SpvOpArbitraryFloatCastFromIntALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatCastToIntINTEL:
+    case SpvOpArbitraryFloatCastToIntALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatAddINTEL:
+    case SpvOpArbitraryFloatAddALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatSubINTEL:
+    case SpvOpArbitraryFloatSubALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatMulINTEL:
+    case SpvOpArbitraryFloatMulALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatDivINTEL:
+    case SpvOpArbitraryFloatDivALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatGTINTEL:
+    case SpvOpArbitraryFloatGTALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatGEINTEL:
+    case SpvOpArbitraryFloatGEALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatLTINTEL:
+    case SpvOpArbitraryFloatLTALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatLEINTEL:
+    case SpvOpArbitraryFloatLEALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatEQINTEL:
+    case SpvOpArbitraryFloatEQALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatRecipINTEL:
+    case SpvOpArbitraryFloatRecipALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatRSqrtINTEL:
+    case SpvOpArbitraryFloatRSqrtALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatCbrtINTEL:
+    case SpvOpArbitraryFloatCbrtALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatHypotINTEL:
+    case SpvOpArbitraryFloatHypotALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpArbitraryFloatSqrtINTEL:
+    case SpvOpArbitraryFloatSqrtALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
@@ -5419,67 +5776,67 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = true;
       *hasResultType = false;
       break;
-    case SpvOpFixedSqrtINTEL:
+    case SpvOpFixedSqrtALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedRecipINTEL:
+    case SpvOpFixedRecipALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedRsqrtINTEL:
+    case SpvOpFixedRsqrtALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedSinINTEL:
+    case SpvOpFixedSinALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedCosINTEL:
+    case SpvOpFixedCosALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedSinCosINTEL:
+    case SpvOpFixedSinCosALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedSinPiINTEL:
+    case SpvOpFixedSinPiALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedCosPiINTEL:
+    case SpvOpFixedCosPiALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedSinCosPiINTEL:
+    case SpvOpFixedSinCosPiALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedLogINTEL:
+    case SpvOpFixedLogALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFixedExpINTEL:
+    case SpvOpFixedExpALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpPtrCastToCrossWorkgroupINTEL:
+    case SpvOpPtrCastToCrossWorkgroupALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpCrossWorkgroupCastToPtrINTEL:
+    case SpvOpCrossWorkgroupCastToPtrALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpReadPipeBlockingINTEL:
+    case SpvOpReadPipeBlockingALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpWritePipeBlockingINTEL:
+    case SpvOpWritePipeBlockingALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpFPGARegINTEL:
+    case SpvOpFPGARegALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
@@ -5595,23 +5952,23 @@ inline void SpvHasResultAndType(SpvOp opcode, bool* hasResult, bool* hasResultTy
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpTaskSequenceCreateINTEL:
+    case SpvOpTaskSequenceCreateALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpTaskSequenceAsyncINTEL:
+    case SpvOpTaskSequenceAsyncALTERA:
       *hasResult = false;
       *hasResultType = false;
       break;
-    case SpvOpTaskSequenceGetINTEL:
+    case SpvOpTaskSequenceGetALTERA:
       *hasResult = true;
       *hasResultType = true;
       break;
-    case SpvOpTaskSequenceReleaseINTEL:
+    case SpvOpTaskSequenceReleaseALTERA:
       *hasResult = false;
       *hasResultType = false;
       break;
-    case SpvOpTypeTaskSequenceINTEL:
+    case SpvOpTypeTaskSequenceALTERA:
       *hasResult = true;
       *hasResultType = false;
       break;
@@ -6001,6 +6358,8 @@ inline const char* SpvExecutionModeToString(SpvExecutionMode value) {
       return "ShadingRateInterlockOrderedEXT";
     case SpvExecutionModeShadingRateInterlockUnorderedEXT:
       return "ShadingRateInterlockUnorderedEXT";
+    case SpvExecutionModeShader64BitIndexingEXT:
+      return "Shader64BitIndexingEXT";
     case SpvExecutionModeSharedLocalMemorySizeINTEL:
       return "SharedLocalMemorySizeINTEL";
     case SpvExecutionModeRoundingModeRTPINTEL:
@@ -6094,12 +6453,14 @@ inline const char* SpvStorageClassToString(SpvStorageClass value) {
       return "HitObjectAttributeNV";
     case SpvStorageClassTaskPayloadWorkgroupEXT:
       return "TaskPayloadWorkgroupEXT";
+    case SpvStorageClassHitObjectAttributeEXT:
+      return "HitObjectAttributeEXT";
     case SpvStorageClassCodeSectionINTEL:
       return "CodeSectionINTEL";
-    case SpvStorageClassDeviceOnlyINTEL:
-      return "DeviceOnlyINTEL";
-    case SpvStorageClassHostOnlyINTEL:
-      return "HostOnlyINTEL";
+    case SpvStorageClassDeviceOnlyALTERA:
+      return "DeviceOnlyALTERA";
+    case SpvStorageClassHostOnlyALTERA:
+      return "HostOnlyALTERA";
     default:
       return "Unknown";
   }
@@ -6412,8 +6773,8 @@ inline const char* SpvFunctionParameterAttributeToString(SpvFunctionParameterAtt
       return "NoWrite";
     case SpvFunctionParameterAttributeNoReadWrite:
       return "NoReadWrite";
-    case SpvFunctionParameterAttributeRuntimeAlignedINTEL:
-      return "RuntimeAlignedINTEL";
+    case SpvFunctionParameterAttributeRuntimeAlignedALTERA:
+      return "RuntimeAlignedALTERA";
     default:
       return "Unknown";
   }
@@ -6545,6 +6906,10 @@ inline const char* SpvDecorationToString(SpvDecoration value) {
       return "PayloadNodeArraySizeAMDX";
     case SpvDecorationPayloadDispatchIndirectAMDX:
       return "PayloadDispatchIndirectAMDX";
+    case SpvDecorationArrayStrideIdEXT:
+      return "ArrayStrideIdEXT";
+    case SpvDecorationOffsetIdEXT:
+      return "OffsetIdEXT";
     case SpvDecorationOverrideCoverageNV:
       return "OverrideCoverageNV";
     case SpvDecorationPassthroughNV:
@@ -6567,8 +6932,14 @@ inline const char* SpvDecorationToString(SpvDecoration value) {
       return "RestrictPointer";
     case SpvDecorationAliasedPointer:
       return "AliasedPointer";
+    case SpvDecorationMemberOffsetNV:
+      return "MemberOffsetNV";
     case SpvDecorationHitObjectShaderRecordBufferNV:
       return "HitObjectShaderRecordBufferNV";
+    case SpvDecorationHitObjectShaderRecordBufferEXT:
+      return "HitObjectShaderRecordBufferEXT";
+    case SpvDecorationBankNV:
+      return "BankNV";
     case SpvDecorationBindlessSamplerNV:
       return "BindlessSamplerNV";
     case SpvDecorationBindlessImageNV:
@@ -6605,64 +6976,64 @@ inline const char* SpvDecorationToString(SpvDecoration value) {
       return "FunctionRoundingModeINTEL";
     case SpvDecorationFunctionDenormModeINTEL:
       return "FunctionDenormModeINTEL";
-    case SpvDecorationRegisterINTEL:
-      return "RegisterINTEL";
-    case SpvDecorationMemoryINTEL:
-      return "MemoryINTEL";
-    case SpvDecorationNumbanksINTEL:
-      return "NumbanksINTEL";
-    case SpvDecorationBankwidthINTEL:
-      return "BankwidthINTEL";
-    case SpvDecorationMaxPrivateCopiesINTEL:
-      return "MaxPrivateCopiesINTEL";
-    case SpvDecorationSinglepumpINTEL:
-      return "SinglepumpINTEL";
-    case SpvDecorationDoublepumpINTEL:
-      return "DoublepumpINTEL";
-    case SpvDecorationMaxReplicatesINTEL:
-      return "MaxReplicatesINTEL";
-    case SpvDecorationSimpleDualPortINTEL:
-      return "SimpleDualPortINTEL";
-    case SpvDecorationMergeINTEL:
-      return "MergeINTEL";
-    case SpvDecorationBankBitsINTEL:
-      return "BankBitsINTEL";
-    case SpvDecorationForcePow2DepthINTEL:
-      return "ForcePow2DepthINTEL";
-    case SpvDecorationStridesizeINTEL:
-      return "StridesizeINTEL";
-    case SpvDecorationWordsizeINTEL:
-      return "WordsizeINTEL";
-    case SpvDecorationTrueDualPortINTEL:
-      return "TrueDualPortINTEL";
-    case SpvDecorationBurstCoalesceINTEL:
-      return "BurstCoalesceINTEL";
-    case SpvDecorationCacheSizeINTEL:
-      return "CacheSizeINTEL";
-    case SpvDecorationDontStaticallyCoalesceINTEL:
-      return "DontStaticallyCoalesceINTEL";
-    case SpvDecorationPrefetchINTEL:
-      return "PrefetchINTEL";
-    case SpvDecorationStallEnableINTEL:
-      return "StallEnableINTEL";
-    case SpvDecorationFuseLoopsInFunctionINTEL:
-      return "FuseLoopsInFunctionINTEL";
-    case SpvDecorationMathOpDSPModeINTEL:
-      return "MathOpDSPModeINTEL";
+    case SpvDecorationRegisterALTERA:
+      return "RegisterALTERA";
+    case SpvDecorationMemoryALTERA:
+      return "MemoryALTERA";
+    case SpvDecorationNumbanksALTERA:
+      return "NumbanksALTERA";
+    case SpvDecorationBankwidthALTERA:
+      return "BankwidthALTERA";
+    case SpvDecorationMaxPrivateCopiesALTERA:
+      return "MaxPrivateCopiesALTERA";
+    case SpvDecorationSinglepumpALTERA:
+      return "SinglepumpALTERA";
+    case SpvDecorationDoublepumpALTERA:
+      return "DoublepumpALTERA";
+    case SpvDecorationMaxReplicatesALTERA:
+      return "MaxReplicatesALTERA";
+    case SpvDecorationSimpleDualPortALTERA:
+      return "SimpleDualPortALTERA";
+    case SpvDecorationMergeALTERA:
+      return "MergeALTERA";
+    case SpvDecorationBankBitsALTERA:
+      return "BankBitsALTERA";
+    case SpvDecorationForcePow2DepthALTERA:
+      return "ForcePow2DepthALTERA";
+    case SpvDecorationStridesizeALTERA:
+      return "StridesizeALTERA";
+    case SpvDecorationWordsizeALTERA:
+      return "WordsizeALTERA";
+    case SpvDecorationTrueDualPortALTERA:
+      return "TrueDualPortALTERA";
+    case SpvDecorationBurstCoalesceALTERA:
+      return "BurstCoalesceALTERA";
+    case SpvDecorationCacheSizeALTERA:
+      return "CacheSizeALTERA";
+    case SpvDecorationDontStaticallyCoalesceALTERA:
+      return "DontStaticallyCoalesceALTERA";
+    case SpvDecorationPrefetchALTERA:
+      return "PrefetchALTERA";
+    case SpvDecorationStallEnableALTERA:
+      return "StallEnableALTERA";
+    case SpvDecorationFuseLoopsInFunctionALTERA:
+      return "FuseLoopsInFunctionALTERA";
+    case SpvDecorationMathOpDSPModeALTERA:
+      return "MathOpDSPModeALTERA";
     case SpvDecorationAliasScopeINTEL:
       return "AliasScopeINTEL";
     case SpvDecorationNoAliasINTEL:
       return "NoAliasINTEL";
-    case SpvDecorationInitiationIntervalINTEL:
-      return "InitiationIntervalINTEL";
-    case SpvDecorationMaxConcurrencyINTEL:
-      return "MaxConcurrencyINTEL";
-    case SpvDecorationPipelineEnableINTEL:
-      return "PipelineEnableINTEL";
-    case SpvDecorationBufferLocationINTEL:
-      return "BufferLocationINTEL";
-    case SpvDecorationIOPipeStorageINTEL:
-      return "IOPipeStorageINTEL";
+    case SpvDecorationInitiationIntervalALTERA:
+      return "InitiationIntervalALTERA";
+    case SpvDecorationMaxConcurrencyALTERA:
+      return "MaxConcurrencyALTERA";
+    case SpvDecorationPipelineEnableALTERA:
+      return "PipelineEnableALTERA";
+    case SpvDecorationBufferLocationALTERA:
+      return "BufferLocationALTERA";
+    case SpvDecorationIOPipeStorageALTERA:
+      return "IOPipeStorageALTERA";
     case SpvDecorationFunctionFloatingPointModeINTEL:
       return "FunctionFloatingPointModeINTEL";
     case SpvDecorationSingleElementVectorINTEL:
@@ -6671,38 +7042,38 @@ inline const char* SpvDecorationToString(SpvDecoration value) {
       return "VectorComputeCallableFunctionINTEL";
     case SpvDecorationMediaBlockIOINTEL:
       return "MediaBlockIOINTEL";
-    case SpvDecorationStallFreeINTEL:
-      return "StallFreeINTEL";
+    case SpvDecorationStallFreeALTERA:
+      return "StallFreeALTERA";
     case SpvDecorationFPMaxErrorDecorationINTEL:
       return "FPMaxErrorDecorationINTEL";
-    case SpvDecorationLatencyControlLabelINTEL:
-      return "LatencyControlLabelINTEL";
-    case SpvDecorationLatencyControlConstraintINTEL:
-      return "LatencyControlConstraintINTEL";
-    case SpvDecorationConduitKernelArgumentINTEL:
-      return "ConduitKernelArgumentINTEL";
-    case SpvDecorationRegisterMapKernelArgumentINTEL:
-      return "RegisterMapKernelArgumentINTEL";
-    case SpvDecorationMMHostInterfaceAddressWidthINTEL:
-      return "MMHostInterfaceAddressWidthINTEL";
-    case SpvDecorationMMHostInterfaceDataWidthINTEL:
-      return "MMHostInterfaceDataWidthINTEL";
-    case SpvDecorationMMHostInterfaceLatencyINTEL:
-      return "MMHostInterfaceLatencyINTEL";
-    case SpvDecorationMMHostInterfaceReadWriteModeINTEL:
-      return "MMHostInterfaceReadWriteModeINTEL";
-    case SpvDecorationMMHostInterfaceMaxBurstINTEL:
-      return "MMHostInterfaceMaxBurstINTEL";
-    case SpvDecorationMMHostInterfaceWaitRequestINTEL:
-      return "MMHostInterfaceWaitRequestINTEL";
-    case SpvDecorationStableKernelArgumentINTEL:
-      return "StableKernelArgumentINTEL";
+    case SpvDecorationLatencyControlLabelALTERA:
+      return "LatencyControlLabelALTERA";
+    case SpvDecorationLatencyControlConstraintALTERA:
+      return "LatencyControlConstraintALTERA";
+    case SpvDecorationConduitKernelArgumentALTERA:
+      return "ConduitKernelArgumentALTERA";
+    case SpvDecorationRegisterMapKernelArgumentALTERA:
+      return "RegisterMapKernelArgumentALTERA";
+    case SpvDecorationMMHostInterfaceAddressWidthALTERA:
+      return "MMHostInterfaceAddressWidthALTERA";
+    case SpvDecorationMMHostInterfaceDataWidthALTERA:
+      return "MMHostInterfaceDataWidthALTERA";
+    case SpvDecorationMMHostInterfaceLatencyALTERA:
+      return "MMHostInterfaceLatencyALTERA";
+    case SpvDecorationMMHostInterfaceReadWriteModeALTERA:
+      return "MMHostInterfaceReadWriteModeALTERA";
+    case SpvDecorationMMHostInterfaceMaxBurstALTERA:
+      return "MMHostInterfaceMaxBurstALTERA";
+    case SpvDecorationMMHostInterfaceWaitRequestALTERA:
+      return "MMHostInterfaceWaitRequestALTERA";
+    case SpvDecorationStableKernelArgumentALTERA:
+      return "StableKernelArgumentALTERA";
     case SpvDecorationHostAccessINTEL:
       return "HostAccessINTEL";
-    case SpvDecorationInitModeINTEL:
-      return "InitModeINTEL";
-    case SpvDecorationImplementInRegisterMapINTEL:
-      return "ImplementInRegisterMapINTEL";
+    case SpvDecorationInitModeALTERA:
+      return "InitModeALTERA";
+    case SpvDecorationImplementInRegisterMapALTERA:
+      return "ImplementInRegisterMapALTERA";
     case SpvDecorationConditionalINTEL:
       return "ConditionalINTEL";
     case SpvDecorationCacheControlLoadINTEL:
@@ -6858,6 +7229,10 @@ inline const char* SpvBuiltInToString(SpvBuiltIn value) {
       return "RemainingRecursionLevelsAMDX";
     case SpvBuiltInShaderIndexAMDX:
       return "ShaderIndexAMDX";
+    case SpvBuiltInSamplerHeapEXT:
+      return "SamplerHeapEXT";
+    case SpvBuiltInResourceHeapEXT:
+      return "ResourceHeapEXT";
     case SpvBuiltInViewportMaskNV:
       return "ViewportMaskNV";
     case SpvBuiltInSecondaryPositionNV:
@@ -7004,12 +7379,12 @@ inline const char* SpvGroupOperationToString(SpvGroupOperation value) {
       return "ExclusiveScan";
     case SpvGroupOperationClusteredReduce:
       return "ClusteredReduce";
-    case SpvGroupOperationPartitionedReduceNV:
-      return "PartitionedReduceNV";
-    case SpvGroupOperationPartitionedInclusiveScanNV:
-      return "PartitionedInclusiveScanNV";
-    case SpvGroupOperationPartitionedExclusiveScanNV:
-      return "PartitionedExclusiveScanNV";
+    case SpvGroupOperationPartitionedReduceEXT:
+      return "PartitionedReduceEXT";
+    case SpvGroupOperationPartitionedInclusiveScanEXT:
+      return "PartitionedInclusiveScanEXT";
+    case SpvGroupOperationPartitionedExclusiveScanEXT:
+      return "PartitionedExclusiveScanEXT";
     default:
       return "Unknown";
   }
@@ -7292,6 +7667,8 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "BFloat16DotProductKHR";
     case SpvCapabilityBFloat16CooperativeMatrixKHR:
       return "BFloat16CooperativeMatrixKHR";
+    case SpvCapabilityDescriptorHeapEXT:
+      return "DescriptorHeapEXT";
     case SpvCapabilitySampleMaskOverrideCoverageNV:
       return "SampleMaskOverrideCoverageNV";
     case SpvCapabilityGeometryShaderPassthroughNV:
@@ -7318,8 +7695,8 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "ComputeDerivativeGroupQuadsKHR";
     case SpvCapabilityFragmentDensityEXT:
       return "FragmentDensityEXT";
-    case SpvCapabilityGroupNonUniformPartitionedNV:
-      return "GroupNonUniformPartitionedNV";
+    case SpvCapabilityGroupNonUniformPartitionedEXT:
+      return "GroupNonUniformPartitionedEXT";
     case SpvCapabilityShaderNonUniform:
       return "ShaderNonUniform";
     case SpvCapabilityRuntimeDescriptorArray:
@@ -7378,6 +7755,8 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "RayTracingOpacityMicromapEXT";
     case SpvCapabilityShaderInvocationReorderNV:
       return "ShaderInvocationReorderNV";
+    case SpvCapabilityShaderInvocationReorderEXT:
+      return "ShaderInvocationReorderEXT";
     case SpvCapabilityBindlessTextureNV:
       return "BindlessTextureNV";
     case SpvCapabilityRayQueryPositionFetchKHR:
@@ -7394,6 +7773,12 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "RayTracingSpheresGeometryNV";
     case SpvCapabilityRayTracingLinearSweptSpheresGeometryNV:
       return "RayTracingLinearSweptSpheresGeometryNV";
+    case SpvCapabilityPushConstantBanksNV:
+      return "PushConstantBanksNV";
+    case SpvCapabilityLongVectorEXT:
+      return "LongVectorEXT";
+    case SpvCapabilityShader64BitIndexingEXT:
+      return "Shader64BitIndexingEXT";
     case SpvCapabilityCooperativeMatrixReductionsNV:
       return "CooperativeMatrixReductionsNV";
     case SpvCapabilityCooperativeMatrixConversionsNV:
@@ -7452,48 +7837,48 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "VariableLengthArrayINTEL";
     case SpvCapabilityFunctionFloatControlINTEL:
       return "FunctionFloatControlINTEL";
-    case SpvCapabilityFPGAMemoryAttributesINTEL:
-      return "FPGAMemoryAttributesINTEL";
+    case SpvCapabilityFPGAMemoryAttributesALTERA:
+      return "FPGAMemoryAttributesALTERA";
     case SpvCapabilityFPFastMathModeINTEL:
       return "FPFastMathModeINTEL";
-    case SpvCapabilityArbitraryPrecisionIntegersINTEL:
-      return "ArbitraryPrecisionIntegersINTEL";
-    case SpvCapabilityArbitraryPrecisionFloatingPointINTEL:
-      return "ArbitraryPrecisionFloatingPointINTEL";
+    case SpvCapabilityArbitraryPrecisionIntegersALTERA:
+      return "ArbitraryPrecisionIntegersALTERA";
+    case SpvCapabilityArbitraryPrecisionFloatingPointALTERA:
+      return "ArbitraryPrecisionFloatingPointALTERA";
     case SpvCapabilityUnstructuredLoopControlsINTEL:
       return "UnstructuredLoopControlsINTEL";
-    case SpvCapabilityFPGALoopControlsINTEL:
-      return "FPGALoopControlsINTEL";
+    case SpvCapabilityFPGALoopControlsALTERA:
+      return "FPGALoopControlsALTERA";
     case SpvCapabilityKernelAttributesINTEL:
       return "KernelAttributesINTEL";
     case SpvCapabilityFPGAKernelAttributesINTEL:
       return "FPGAKernelAttributesINTEL";
-    case SpvCapabilityFPGAMemoryAccessesINTEL:
-      return "FPGAMemoryAccessesINTEL";
-    case SpvCapabilityFPGAClusterAttributesINTEL:
-      return "FPGAClusterAttributesINTEL";
-    case SpvCapabilityLoopFuseINTEL:
-      return "LoopFuseINTEL";
-    case SpvCapabilityFPGADSPControlINTEL:
-      return "FPGADSPControlINTEL";
+    case SpvCapabilityFPGAMemoryAccessesALTERA:
+      return "FPGAMemoryAccessesALTERA";
+    case SpvCapabilityFPGAClusterAttributesALTERA:
+      return "FPGAClusterAttributesALTERA";
+    case SpvCapabilityLoopFuseALTERA:
+      return "LoopFuseALTERA";
+    case SpvCapabilityFPGADSPControlALTERA:
+      return "FPGADSPControlALTERA";
     case SpvCapabilityMemoryAccessAliasingINTEL:
       return "MemoryAccessAliasingINTEL";
-    case SpvCapabilityFPGAInvocationPipeliningAttributesINTEL:
-      return "FPGAInvocationPipeliningAttributesINTEL";
-    case SpvCapabilityFPGABufferLocationINTEL:
-      return "FPGABufferLocationINTEL";
-    case SpvCapabilityArbitraryPrecisionFixedPointINTEL:
-      return "ArbitraryPrecisionFixedPointINTEL";
-    case SpvCapabilityUSMStorageClassesINTEL:
-      return "USMStorageClassesINTEL";
-    case SpvCapabilityRuntimeAlignedAttributeINTEL:
-      return "RuntimeAlignedAttributeINTEL";
-    case SpvCapabilityIOPipesINTEL:
-      return "IOPipesINTEL";
-    case SpvCapabilityBlockingPipesINTEL:
-      return "BlockingPipesINTEL";
-    case SpvCapabilityFPGARegINTEL:
-      return "FPGARegINTEL";
+    case SpvCapabilityFPGAInvocationPipeliningAttributesALTERA:
+      return "FPGAInvocationPipeliningAttributesALTERA";
+    case SpvCapabilityFPGABufferLocationALTERA:
+      return "FPGABufferLocationALTERA";
+    case SpvCapabilityArbitraryPrecisionFixedPointALTERA:
+      return "ArbitraryPrecisionFixedPointALTERA";
+    case SpvCapabilityUSMStorageClassesALTERA:
+      return "USMStorageClassesALTERA";
+    case SpvCapabilityRuntimeAlignedAttributeALTERA:
+      return "RuntimeAlignedAttributeALTERA";
+    case SpvCapabilityIOPipesALTERA:
+      return "IOPipesALTERA";
+    case SpvCapabilityBlockingPipesALTERA:
+      return "BlockingPipesALTERA";
+    case SpvCapabilityFPGARegALTERA:
+      return "FPGARegALTERA";
     case SpvCapabilityDotProductInputAll:
       return "DotProductInputAll";
     case SpvCapabilityDotProductInput4x8Bit:
@@ -7514,6 +7899,8 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "GroupNonUniformRotateKHR";
     case SpvCapabilityFloatControls2:
       return "FloatControls2";
+    case SpvCapabilityFMAKHR:
+      return "FMAKHR";
     case SpvCapabilityAtomicFloat32AddEXT:
       return "AtomicFloat32AddEXT";
     case SpvCapabilityAtomicFloat64AddEXT:
@@ -7532,22 +7919,22 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
       return "SplitBarrierINTEL";
     case SpvCapabilityArithmeticFenceEXT:
       return "ArithmeticFenceEXT";
-    case SpvCapabilityFPGAClusterAttributesV2INTEL:
-      return "FPGAClusterAttributesV2INTEL";
+    case SpvCapabilityFPGAClusterAttributesV2ALTERA:
+      return "FPGAClusterAttributesV2ALTERA";
     case SpvCapabilityFPGAKernelAttributesv2INTEL:
       return "FPGAKernelAttributesv2INTEL";
-    case SpvCapabilityTaskSequenceINTEL:
-      return "TaskSequenceINTEL";
+    case SpvCapabilityTaskSequenceALTERA:
+      return "TaskSequenceALTERA";
     case SpvCapabilityFPMaxErrorINTEL:
       return "FPMaxErrorINTEL";
-    case SpvCapabilityFPGALatencyControlINTEL:
-      return "FPGALatencyControlINTEL";
-    case SpvCapabilityFPGAArgumentInterfacesINTEL:
-      return "FPGAArgumentInterfacesINTEL";
+    case SpvCapabilityFPGALatencyControlALTERA:
+      return "FPGALatencyControlALTERA";
+    case SpvCapabilityFPGAArgumentInterfacesALTERA:
+      return "FPGAArgumentInterfacesALTERA";
     case SpvCapabilityGlobalVariableHostAccessINTEL:
       return "GlobalVariableHostAccessINTEL";
-    case SpvCapabilityGlobalVariableFPGADecorationsINTEL:
-      return "GlobalVariableFPGADecorationsINTEL";
+    case SpvCapabilityGlobalVariableFPGADecorationsALTERA:
+      return "GlobalVariableFPGADecorationsALTERA";
     case SpvCapabilitySubgroupBufferPrefetchINTEL:
       return "SubgroupBufferPrefetchINTEL";
     case SpvCapabilitySubgroup2DBlockIOINTEL:
@@ -7734,10 +8121,10 @@ inline const char* SpvTensorClampModeToString(SpvTensorClampMode value) {
 
 inline const char* SpvInitializationModeQualifierToString(SpvInitializationModeQualifier value) {
   switch (value) {
-    case SpvInitializationModeQualifierInitOnDeviceReprogramINTEL:
-      return "InitOnDeviceReprogramINTEL";
-    case SpvInitializationModeQualifierInitOnDeviceResetINTEL:
-      return "InitOnDeviceResetINTEL";
+    case SpvInitializationModeQualifierInitOnDeviceReprogramALTERA:
+      return "InitOnDeviceReprogramALTERA";
+    case SpvInitializationModeQualifierInitOnDeviceResetALTERA:
+      return "InitOnDeviceResetALTERA";
     default:
       return "Unknown";
   }
@@ -8604,6 +8991,8 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpUntypedArrayLengthKHR";
     case SpvOpUntypedPrefetchKHR:
       return "OpUntypedPrefetchKHR";
+    case SpvOpFmaKHR:
+      return "OpFmaKHR";
     case SpvOpSubgroupAllKHR:
       return "OpSubgroupAllKHR";
     case SpvOpSubgroupAnyKHR:
@@ -8736,6 +9125,16 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpGroupNonUniformQuadAllKHR";
     case SpvOpGroupNonUniformQuadAnyKHR:
       return "OpGroupNonUniformQuadAnyKHR";
+    case SpvOpTypeBufferEXT:
+      return "OpTypeBufferEXT";
+    case SpvOpBufferPointerEXT:
+      return "OpBufferPointerEXT";
+    case SpvOpUntypedImageTexelPointerEXT:
+      return "OpUntypedImageTexelPointerEXT";
+    case SpvOpMemberDecorateIdEXT:
+      return "OpMemberDecorateIdEXT";
+    case SpvOpConstantSizeOfEXT:
+      return "OpConstantSizeOfEXT";
     case SpvOpHitObjectRecordHitMotionNV:
       return "OpHitObjectRecordHitMotionNV";
     case SpvOpHitObjectRecordHitWithIndexMotionNV:
@@ -8820,8 +9219,8 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpEmitMeshTasksEXT";
     case SpvOpSetMeshOutputsEXT:
       return "OpSetMeshOutputsEXT";
-    case SpvOpGroupNonUniformPartitionNV:
-      return "OpGroupNonUniformPartitionNV";
+    case SpvOpGroupNonUniformPartitionEXT:
+      return "OpGroupNonUniformPartitionEXT";
     case SpvOpWritePackedPrimitiveIndices4x8NV:
       return "OpWritePackedPrimitiveIndices4x8NV";
     case SpvOpFetchMicroTriangleVertexPositionNV:
@@ -8832,6 +9231,66 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpCooperativeVectorLoadNV";
     case SpvOpCooperativeVectorStoreNV:
       return "OpCooperativeVectorStoreNV";
+    case SpvOpHitObjectRecordFromQueryEXT:
+      return "OpHitObjectRecordFromQueryEXT";
+    case SpvOpHitObjectRecordMissEXT:
+      return "OpHitObjectRecordMissEXT";
+    case SpvOpHitObjectRecordMissMotionEXT:
+      return "OpHitObjectRecordMissMotionEXT";
+    case SpvOpHitObjectGetIntersectionTriangleVertexPositionsEXT:
+      return "OpHitObjectGetIntersectionTriangleVertexPositionsEXT";
+    case SpvOpHitObjectGetRayFlagsEXT:
+      return "OpHitObjectGetRayFlagsEXT";
+    case SpvOpHitObjectSetShaderBindingTableRecordIndexEXT:
+      return "OpHitObjectSetShaderBindingTableRecordIndexEXT";
+    case SpvOpHitObjectReorderExecuteShaderEXT:
+      return "OpHitObjectReorderExecuteShaderEXT";
+    case SpvOpHitObjectTraceReorderExecuteEXT:
+      return "OpHitObjectTraceReorderExecuteEXT";
+    case SpvOpHitObjectTraceMotionReorderExecuteEXT:
+      return "OpHitObjectTraceMotionReorderExecuteEXT";
+    case SpvOpTypeHitObjectEXT:
+      return "OpTypeHitObjectEXT";
+    case SpvOpReorderThreadWithHintEXT:
+      return "OpReorderThreadWithHintEXT";
+    case SpvOpReorderThreadWithHitObjectEXT:
+      return "OpReorderThreadWithHitObjectEXT";
+    case SpvOpHitObjectTraceRayEXT:
+      return "OpHitObjectTraceRayEXT";
+    case SpvOpHitObjectTraceRayMotionEXT:
+      return "OpHitObjectTraceRayMotionEXT";
+    case SpvOpHitObjectRecordEmptyEXT:
+      return "OpHitObjectRecordEmptyEXT";
+    case SpvOpHitObjectExecuteShaderEXT:
+      return "OpHitObjectExecuteShaderEXT";
+    case SpvOpHitObjectGetCurrentTimeEXT:
+      return "OpHitObjectGetCurrentTimeEXT";
+    case SpvOpHitObjectGetAttributesEXT:
+      return "OpHitObjectGetAttributesEXT";
+    case SpvOpHitObjectGetHitKindEXT:
+      return "OpHitObjectGetHitKindEXT";
+    case SpvOpHitObjectGetPrimitiveIndexEXT:
+      return "OpHitObjectGetPrimitiveIndexEXT";
+    case SpvOpHitObjectGetGeometryIndexEXT:
+      return "OpHitObjectGetGeometryIndexEXT";
+    case SpvOpHitObjectGetInstanceIdEXT:
+      return "OpHitObjectGetInstanceIdEXT";
+    case SpvOpHitObjectGetInstanceCustomIndexEXT:
+      return "OpHitObjectGetInstanceCustomIndexEXT";
+    case SpvOpHitObjectGetObjectRayOriginEXT:
+      return "OpHitObjectGetObjectRayOriginEXT";
+    case SpvOpHitObjectGetObjectRayDirectionEXT:
+      return "OpHitObjectGetObjectRayDirectionEXT";
+    case SpvOpHitObjectGetWorldRayDirectionEXT:
+      return "OpHitObjectGetWorldRayDirectionEXT";
+    case SpvOpHitObjectGetWorldRayOriginEXT:
+      return "OpHitObjectGetWorldRayOriginEXT";
+    case SpvOpHitObjectGetObjectToWorldEXT:
+      return "OpHitObjectGetObjectToWorldEXT";
+    case SpvOpHitObjectGetWorldToObjectEXT:
+      return "OpHitObjectGetWorldToObjectEXT";
+    case SpvOpHitObjectGetRayTMaxEXT:
+      return "OpHitObjectGetRayTMaxEXT";
     case SpvOpReportIntersectionKHR:
       return "OpReportIntersectionKHR";
     case SpvOpIgnoreIntersectionNV:
@@ -8854,6 +9313,18 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpRayQueryGetClusterIdNV";
     case SpvOpHitObjectGetClusterIdNV:
       return "OpHitObjectGetClusterIdNV";
+    case SpvOpHitObjectGetRayTMinEXT:
+      return "OpHitObjectGetRayTMinEXT";
+    case SpvOpHitObjectGetShaderBindingTableRecordIndexEXT:
+      return "OpHitObjectGetShaderBindingTableRecordIndexEXT";
+    case SpvOpHitObjectGetShaderRecordBufferHandleEXT:
+      return "OpHitObjectGetShaderRecordBufferHandleEXT";
+    case SpvOpHitObjectIsEmptyEXT:
+      return "OpHitObjectIsEmptyEXT";
+    case SpvOpHitObjectIsHitEXT:
+      return "OpHitObjectIsHitEXT";
+    case SpvOpHitObjectIsMissEXT:
+      return "OpHitObjectIsMissEXT";
     case SpvOpTypeCooperativeMatrixNV:
       return "OpTypeCooperativeMatrixNV";
     case SpvOpCooperativeMatrixLoadNV:
@@ -9260,42 +9731,42 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpSaveMemoryINTEL";
     case SpvOpRestoreMemoryINTEL:
       return "OpRestoreMemoryINTEL";
-    case SpvOpArbitraryFloatSinCosPiINTEL:
-      return "OpArbitraryFloatSinCosPiINTEL";
-    case SpvOpArbitraryFloatCastINTEL:
-      return "OpArbitraryFloatCastINTEL";
-    case SpvOpArbitraryFloatCastFromIntINTEL:
-      return "OpArbitraryFloatCastFromIntINTEL";
-    case SpvOpArbitraryFloatCastToIntINTEL:
-      return "OpArbitraryFloatCastToIntINTEL";
-    case SpvOpArbitraryFloatAddINTEL:
-      return "OpArbitraryFloatAddINTEL";
-    case SpvOpArbitraryFloatSubINTEL:
-      return "OpArbitraryFloatSubINTEL";
-    case SpvOpArbitraryFloatMulINTEL:
-      return "OpArbitraryFloatMulINTEL";
-    case SpvOpArbitraryFloatDivINTEL:
-      return "OpArbitraryFloatDivINTEL";
-    case SpvOpArbitraryFloatGTINTEL:
-      return "OpArbitraryFloatGTINTEL";
-    case SpvOpArbitraryFloatGEINTEL:
-      return "OpArbitraryFloatGEINTEL";
-    case SpvOpArbitraryFloatLTINTEL:
-      return "OpArbitraryFloatLTINTEL";
-    case SpvOpArbitraryFloatLEINTEL:
-      return "OpArbitraryFloatLEINTEL";
-    case SpvOpArbitraryFloatEQINTEL:
-      return "OpArbitraryFloatEQINTEL";
-    case SpvOpArbitraryFloatRecipINTEL:
-      return "OpArbitraryFloatRecipINTEL";
-    case SpvOpArbitraryFloatRSqrtINTEL:
-      return "OpArbitraryFloatRSqrtINTEL";
-    case SpvOpArbitraryFloatCbrtINTEL:
-      return "OpArbitraryFloatCbrtINTEL";
-    case SpvOpArbitraryFloatHypotINTEL:
-      return "OpArbitraryFloatHypotINTEL";
-    case SpvOpArbitraryFloatSqrtINTEL:
-      return "OpArbitraryFloatSqrtINTEL";
+    case SpvOpArbitraryFloatSinCosPiALTERA:
+      return "OpArbitraryFloatSinCosPiALTERA";
+    case SpvOpArbitraryFloatCastALTERA:
+      return "OpArbitraryFloatCastALTERA";
+    case SpvOpArbitraryFloatCastFromIntALTERA:
+      return "OpArbitraryFloatCastFromIntALTERA";
+    case SpvOpArbitraryFloatCastToIntALTERA:
+      return "OpArbitraryFloatCastToIntALTERA";
+    case SpvOpArbitraryFloatAddALTERA:
+      return "OpArbitraryFloatAddALTERA";
+    case SpvOpArbitraryFloatSubALTERA:
+      return "OpArbitraryFloatSubALTERA";
+    case SpvOpArbitraryFloatMulALTERA:
+      return "OpArbitraryFloatMulALTERA";
+    case SpvOpArbitraryFloatDivALTERA:
+      return "OpArbitraryFloatDivALTERA";
+    case SpvOpArbitraryFloatGTALTERA:
+      return "OpArbitraryFloatGTALTERA";
+    case SpvOpArbitraryFloatGEALTERA:
+      return "OpArbitraryFloatGEALTERA";
+    case SpvOpArbitraryFloatLTALTERA:
+      return "OpArbitraryFloatLTALTERA";
+    case SpvOpArbitraryFloatLEALTERA:
+      return "OpArbitraryFloatLEALTERA";
+    case SpvOpArbitraryFloatEQALTERA:
+      return "OpArbitraryFloatEQALTERA";
+    case SpvOpArbitraryFloatRecipALTERA:
+      return "OpArbitraryFloatRecipALTERA";
+    case SpvOpArbitraryFloatRSqrtALTERA:
+      return "OpArbitraryFloatRSqrtALTERA";
+    case SpvOpArbitraryFloatCbrtALTERA:
+      return "OpArbitraryFloatCbrtALTERA";
+    case SpvOpArbitraryFloatHypotALTERA:
+      return "OpArbitraryFloatHypotALTERA";
+    case SpvOpArbitraryFloatSqrtALTERA:
+      return "OpArbitraryFloatSqrtALTERA";
     case SpvOpArbitraryFloatLogINTEL:
       return "OpArbitraryFloatLogINTEL";
     case SpvOpArbitraryFloatLog2INTEL:
@@ -9350,38 +9821,38 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpAliasScopeDeclINTEL";
     case SpvOpAliasScopeListDeclINTEL:
       return "OpAliasScopeListDeclINTEL";
-    case SpvOpFixedSqrtINTEL:
-      return "OpFixedSqrtINTEL";
-    case SpvOpFixedRecipINTEL:
-      return "OpFixedRecipINTEL";
-    case SpvOpFixedRsqrtINTEL:
-      return "OpFixedRsqrtINTEL";
-    case SpvOpFixedSinINTEL:
-      return "OpFixedSinINTEL";
-    case SpvOpFixedCosINTEL:
-      return "OpFixedCosINTEL";
-    case SpvOpFixedSinCosINTEL:
-      return "OpFixedSinCosINTEL";
-    case SpvOpFixedSinPiINTEL:
-      return "OpFixedSinPiINTEL";
-    case SpvOpFixedCosPiINTEL:
-      return "OpFixedCosPiINTEL";
-    case SpvOpFixedSinCosPiINTEL:
-      return "OpFixedSinCosPiINTEL";
-    case SpvOpFixedLogINTEL:
-      return "OpFixedLogINTEL";
-    case SpvOpFixedExpINTEL:
-      return "OpFixedExpINTEL";
-    case SpvOpPtrCastToCrossWorkgroupINTEL:
-      return "OpPtrCastToCrossWorkgroupINTEL";
-    case SpvOpCrossWorkgroupCastToPtrINTEL:
-      return "OpCrossWorkgroupCastToPtrINTEL";
-    case SpvOpReadPipeBlockingINTEL:
-      return "OpReadPipeBlockingINTEL";
-    case SpvOpWritePipeBlockingINTEL:
-      return "OpWritePipeBlockingINTEL";
-    case SpvOpFPGARegINTEL:
-      return "OpFPGARegINTEL";
+    case SpvOpFixedSqrtALTERA:
+      return "OpFixedSqrtALTERA";
+    case SpvOpFixedRecipALTERA:
+      return "OpFixedRecipALTERA";
+    case SpvOpFixedRsqrtALTERA:
+      return "OpFixedRsqrtALTERA";
+    case SpvOpFixedSinALTERA:
+      return "OpFixedSinALTERA";
+    case SpvOpFixedCosALTERA:
+      return "OpFixedCosALTERA";
+    case SpvOpFixedSinCosALTERA:
+      return "OpFixedSinCosALTERA";
+    case SpvOpFixedSinPiALTERA:
+      return "OpFixedSinPiALTERA";
+    case SpvOpFixedCosPiALTERA:
+      return "OpFixedCosPiALTERA";
+    case SpvOpFixedSinCosPiALTERA:
+      return "OpFixedSinCosPiALTERA";
+    case SpvOpFixedLogALTERA:
+      return "OpFixedLogALTERA";
+    case SpvOpFixedExpALTERA:
+      return "OpFixedExpALTERA";
+    case SpvOpPtrCastToCrossWorkgroupALTERA:
+      return "OpPtrCastToCrossWorkgroupALTERA";
+    case SpvOpCrossWorkgroupCastToPtrALTERA:
+      return "OpCrossWorkgroupCastToPtrALTERA";
+    case SpvOpReadPipeBlockingALTERA:
+      return "OpReadPipeBlockingALTERA";
+    case SpvOpWritePipeBlockingALTERA:
+      return "OpWritePipeBlockingALTERA";
+    case SpvOpFPGARegALTERA:
+      return "OpFPGARegALTERA";
     case SpvOpRayQueryGetRayTMinKHR:
       return "OpRayQueryGetRayTMinKHR";
     case SpvOpRayQueryGetRayFlagsKHR:
@@ -9438,16 +9909,16 @@ inline const char* SpvOpToString(SpvOp value) {
       return "OpControlBarrierWaitINTEL";
     case SpvOpArithmeticFenceEXT:
       return "OpArithmeticFenceEXT";
-    case SpvOpTaskSequenceCreateINTEL:
-      return "OpTaskSequenceCreateINTEL";
-    case SpvOpTaskSequenceAsyncINTEL:
-      return "OpTaskSequenceAsyncINTEL";
-    case SpvOpTaskSequenceGetINTEL:
-      return "OpTaskSequenceGetINTEL";
-    case SpvOpTaskSequenceReleaseINTEL:
-      return "OpTaskSequenceReleaseINTEL";
-    case SpvOpTypeTaskSequenceINTEL:
-      return "OpTypeTaskSequenceINTEL";
+    case SpvOpTaskSequenceCreateALTERA:
+      return "OpTaskSequenceCreateALTERA";
+    case SpvOpTaskSequenceAsyncALTERA:
+      return "OpTaskSequenceAsyncALTERA";
+    case SpvOpTaskSequenceGetALTERA:
+      return "OpTaskSequenceGetALTERA";
+    case SpvOpTaskSequenceReleaseALTERA:
+      return "OpTaskSequenceReleaseALTERA";
+    case SpvOpTypeTaskSequenceALTERA:
+      return "OpTypeTaskSequenceALTERA";
     case SpvOpSubgroupBlockPrefetchINTEL:
       return "OpSubgroupBlockPrefetchINTEL";
     case SpvOpSubgroup2DBlockLoadINTEL:

--- a/spirv_reflect.c
+++ b/spirv_reflect.c
@@ -846,6 +846,7 @@ static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser) {
       case SpvOpTypeAccelerationStructureKHR:
       case SpvOpTypeRayQueryKHR:
       case SpvOpTypeHitObjectNV:
+      case SpvOpTypeHitObjectEXT:
       case SpvOpTypeCooperativeVectorNV:
       case SpvOpTypeCooperativeMatrixNV:
       case SpvOpTypeCooperativeMatrixKHR: {


### PR DESCRIPTION
Currently only the nvidia extension for invocation reordering is supported.

This PR adds support for the new-ish cross vendor extension and also updates the spirv headers to the latest release (1.4.341).